### PR TITLE
Layout Builder: 결함 수정 + 프롬프트 품질 보조 + 편집 UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,9 @@ RandomNoise -> LTXVConcatAVLatent -> CFGGuider -> KSamplerSelect -> ManualSigmas
   시작용 박스 세트를 깔아주며, 세 개의 토글이 출력을 제어합니다: `strict_text`
   (정확한 철자 렌더링 힌트), `reinforce_text`(`desc`에 글자 그대로를 한 번 더
   반복 — 끄면 컴팩트 JSON), `include_global_palette`(전역 팔레트를 생략해 색을
-  열어둠).
+  열어둠). 편집 보조로 **레이어 리스트**(가려진 박스도 클릭해 선택 + 앞/뒤 순서
+  변경 + 삭제)와 **키보드 단축키**(캔버스 포커스 상태에서 Delete/Backspace 삭제,
+  방향키 이동 · Shift로 크게 이동, Esc 선택 해제)를 제공합니다.
 - `ideogram4_t2i_node` (`toobusy Ideogram4 T2I`) — 프롬프트로부터 로컬 Ideogram 4
   모델(CLIP `ideogram4`, `Ideogram4Scheduler`)을 실행합니다. Layout Builder의 JSON
   프롬프트와 `width`/`height`를 그대로 받습니다.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The current public focus is:
 - `toobusy LTX2.3` compact workflow nodes
 - `toobusy Z-Image Turbo`
 
-Experimental older nodes are kept in the repository for reference, but are not registered by default right now.
+A few additional/experimental nodes (including the Ideogram Layout Builder and Ideogram4 T2I) are also registered — see [Additional / Experimental Nodes](#additional--experimental-nodes).
 
 ## Install
 
@@ -274,14 +274,19 @@ If `sigmas` is connected, the node uses that injected sigma schedule. Otherwise 
 
 The node always runs `LTXVCropGuides` after sampling so guide frames are removed before the latent continues.
 
-## Hidden Experimental Nodes
+## Additional / Experimental Nodes
 
-These folders are currently kept in the repository but are not exposed through `NODE_CLASS_MAPPINGS`:
+These nodes are also registered through `NODE_CLASS_MAPPINGS` (so they appear in
+the node menu), but are less polished than the core set above:
 
-- `hf_model_auto_loader`
-- `ideogram_layout_builder`
-
-They may come back later, but they are hidden for now to keep the public node list focused.
+- `hf_model_auto_loader` — auto-resolves/downloads Hugging Face model files.
+- `ideogram_layout_builder` (`toobusy Ideogram Layout Builder`) — a visual bbox
+  editor that emits an Ideogram 4 structured-prompt JSON plus `width`/`height`.
+  Draw regions on the canvas, mark each as text or object, set global/per-element
+  palettes, and wire the JSON into a text encoder.
+- `ideogram4_t2i_node` (`toobusy Ideogram4 T2I`) — runs a local Ideogram 4 model
+  (CLIP `ideogram4`, `Ideogram4Scheduler`) from a prompt; accepts the Layout
+  Builder's JSON prompt and `width`/`height` directly.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -1,161 +1,161 @@
 # toobusy
 
-ComfyUI custom nodes for reducing busy video-generation workflows.
+복잡한 영상 생성 워크플로우를 단순하게 만들어주는 ComfyUI 커스텀 노드 모음입니다.
 
-The current public focus is:
+현재 공개 중점 노드:
 
 - `toobusy Keyframe Maker`
 - `toobusy Prompt Lines`
 - `toobusy Storyboard Board`
-- `toobusy LTX2.3` compact workflow nodes
+- `toobusy LTX2.3` 컴팩트 워크플로우 노드들
 - `toobusy Z-Image Turbo`
 
-A few additional/experimental nodes (including the Ideogram Layout Builder and Ideogram4 T2I) are also registered — see [Additional / Experimental Nodes](#additional--experimental-nodes).
+이 외에도 몇 개의 추가/실험적 노드(Ideogram Layout Builder, Ideogram4 T2I 포함)가 함께 등록되어 있습니다 — [추가 / 실험적 노드](#추가--실험적-노드) 참고.
 
-## Install
+## 설치
 
-Clone this repository into `ComfyUI/custom_nodes` as `toobusy`, then restart ComfyUI.
+이 저장소를 `ComfyUI/custom_nodes` 아래에 `toobusy`라는 이름으로 클론한 뒤 ComfyUI를 재시작하세요.
 
 ```bash
 cd ComfyUI/custom_nodes
 git clone https://github.com/nicekriss/toobusy.git toobusy
 ```
 
-Update later with:
+이후 업데이트:
 
 ```bash
 cd ComfyUI/custom_nodes/toobusy
 git pull
 ```
 
-After pulling frontend changes, restart ComfyUI and hard-refresh the browser.
+프런트엔드(JS) 변경을 받은 뒤에는 ComfyUI를 재시작하고 브라우저를 강력 새로고침(hard refresh) 하세요.
 
-## Active Nodes
+## 활성 노드
 
 ### toobusy Keyframe Maker
 
-Category:
+카테고리:
 
 ```text
 toobusy/Keyframe
 ```
 
-This node turns an optional reference image and a short idea into storyboard/keyframe text outputs.
-It can be used for product commercials, music videos, and short drama-style sequences.
+선택적인 참조 이미지와 짧은 아이디어를 스토리보드/키프레임 텍스트 출력으로 바꿔주는 노드입니다.
+제품 광고, 뮤직비디오, 단편 드라마 형식의 시퀀스에 사용할 수 있습니다.
 
-Modes:
+모드:
 
-- `Product Commercial`: analyzes the image as a product reference and plans a commercial sequence.
-- `Music Video`: analyzes the image as a subject/visual reference and plans a mood-driven music-video sequence.
-- `Short Drama`: analyzes the image as a subject/visual reference and plans a short narrative sequence.
+- `Product Commercial`: 이미지를 제품 참조로 분석하여 광고 시퀀스를 구성합니다.
+- `Music Video`: 이미지를 인물/비주얼 참조로 분석하여 무드 중심의 뮤직비디오 시퀀스를 구성합니다.
+- `Short Drama`: 이미지를 인물/비주얼 참조로 분석하여 짧은 내러티브 시퀀스를 구성합니다.
 
-Inputs:
+입력:
 
-- `clip`: a text-generation capable CLIP/text encoder, for example the Gemma/LTX text model used by ComfyUI `TextGenerate`.
-- `product_image` optional: product, subject, or visual reference image. If omitted, the node builds a reference brief from `idea`, `style`, and `fixed_elements`.
-- `mode`: storyboard mode. Current options are `Product Commercial`, `Music Video`, and `Short Drama`.
-- `idea`: the core event, transformation, story hook, or scene direction.
-- `style`: visual tone, camera style, lighting, mood, genre.
-- `fixed_elements`: product/character/colors/background rules that should remain consistent across shots.
-- `shot_count`: number of shots to generate when `shot_beats_override` is empty.
-- `seed`: base seed. The node uses `seed`, `seed + 1`, `seed + 2`, and `seed + 3` across its internal text-generation stages.
-- `product_brief_override` optional: if filled, image/text brief generation is skipped and this text is used as the reference brief.
-- `shot_beats_override` optional: if filled, shot-beat generation is skipped.
+- `clip`: 텍스트 생성이 가능한 CLIP/텍스트 인코더. 예를 들어 ComfyUI `TextGenerate`에서 쓰는 Gemma/LTX 텍스트 모델.
+- `product_image` (선택): 제품·인물·비주얼 참조 이미지. 생략하면 `idea`, `style`, `fixed_elements`로부터 참조 브리프를 만듭니다.
+- `mode`: 스토리보드 모드. 현재 옵션은 `Product Commercial`, `Music Video`, `Short Drama`.
+- `idea`: 핵심 사건, 변화, 스토리 훅, 또는 장면 방향.
+- `style`: 비주얼 톤, 카메라 스타일, 조명, 무드, 장르.
+- `fixed_elements`: 모든 샷에서 일관되게 유지되어야 하는 제품/캐릭터/색상/배경 규칙.
+- `shot_count`: `shot_beats_override`가 비어 있을 때 생성할 샷 개수.
+- `seed`: 기본 시드. 내부 텍스트 생성 단계에서 `seed`, `seed + 1`, `seed + 2`, `seed + 3`을 사용합니다.
+- `product_brief_override` (선택): 채워져 있으면 이미지/텍스트 브리프 생성을 건너뛰고 이 텍스트를 참조 브리프로 사용합니다.
+- `shot_beats_override` (선택): 채워져 있으면 샷 비트 생성을 건너뜁니다.
 
-Outputs:
+출력:
 
-- `product_brief`: compatibility name for the generated reference brief. In non-product modes this is a subject/visual brief.
+- `product_brief`: 생성된 참조 브리프의 호환용 이름. 제품 모드가 아닐 때는 인물/비주얼 브리프입니다.
 - `shot_beats`
 - `keyframe_prompts`
 - `korean_story`
 
-Internal flow:
+내부 흐름:
 
 ```text
-product_image + mode -> reference brief
-or idea + style + fixed + mode -> reference brief
-reference brief + idea + style + fixed + shot_count -> shot beats
-shot beats + reference brief + style + fixed -> keyframe prompts
-brief + idea + style + beats + keyframe prompts -> Korean story explanation
+product_image + mode -> 참조 브리프
+또는 idea + style + fixed + mode -> 참조 브리프
+참조 브리프 + idea + style + fixed + shot_count -> 샷 비트
+샷 비트 + 참조 브리프 + style + fixed -> 키프레임 프롬프트
+브리프 + idea + style + 비트 + 키프레임 프롬프트 -> 한국어 스토리 설명
 ```
 
-Override behavior:
+오버라이드 동작:
 
-- If `product_brief_override` is filled, the image/text brief generation result is ignored.
-- If `shot_beats_override` is filled, shot-beat generation is ignored.
-- When `shot_beats_override` is used, the effective shot count is the number of non-empty lines in the override text, not the `shot_count` widget.
+- `product_brief_override`가 채워져 있으면 이미지/텍스트 브리프 생성 결과는 무시됩니다.
+- `shot_beats_override`가 채워져 있으면 샷 비트 생성은 무시됩니다.
+- `shot_beats_override`를 사용할 때 실제 샷 개수는 `shot_count` 위젯이 아니라 오버라이드 텍스트의 비어 있지 않은 줄 수가 됩니다.
 
-The frontend adds a small toobusy-tinted input guide and summary panel so the node remains readable after text is entered.
+프런트엔드는 텍스트 입력 후에도 노드가 읽기 쉽도록 toobusy 색조의 입력 가이드와 요약 패널을 덧붙입니다.
 
 ### toobusy Prompt Lines
 
-Category:
+카테고리:
 
 ```text
 toobusy/Text
 ```
 
-Splits multiline text into line-by-line prompt items, so `toobusy Keyframe Maker.keyframe_prompts` can be used without another custom PromptLine-style node.
+여러 줄 텍스트를 한 줄씩 프롬프트 항목으로 분리합니다. 덕분에 별도의 PromptLine 류 커스텀 노드 없이도 `toobusy Keyframe Maker.keyframe_prompts`를 바로 사용할 수 있습니다.
 
-Inputs:
+입력:
 
-- `source`: multiline text to split.
-- `start_index`: first line index to use, zero-based.
-- `max_rows`: maximum number of lines to output.
-- `remove_empty_lines`: removes blank lines before slicing.
-- `strip_lines`: trims whitespace from each line.
+- `source`: 분리할 여러 줄 텍스트.
+- `start_index`: 사용할 첫 줄 인덱스(0부터 시작).
+- `max_rows`: 출력할 최대 줄 수.
+- `remove_empty_lines`: 슬라이싱 전에 빈 줄을 제거합니다.
+- `strip_lines`: 각 줄의 앞뒤 공백을 제거합니다.
 
-Outputs:
+출력:
 
-- `line`: list output. Connect this to a prompt/string input to run downstream nodes once per selected line.
-- `text`: selected lines joined back into one multiline string.
-- `count`: number of selected non-empty lines.
+- `line`: 리스트 출력. 프롬프트/문자열 입력에 연결하면 선택된 각 줄마다 하위 노드를 한 번씩 실행합니다.
+- `text`: 선택된 줄들을 다시 하나의 여러 줄 문자열로 합친 값.
+- `count`: 선택된 비어 있지 않은 줄 수.
 
 ### toobusy Storyboard Board
 
-Category:
+카테고리:
 
 ```text
 toobusy/Storyboard
 ```
 
-A small whiteboard/moodboard node for planning video ideas, storylines, visual references, and shot structure inside ComfyUI.
-It is inspired by canvas-style creative workspaces, but it stays local and exports a normal ComfyUI `IMAGE`.
+ComfyUI 안에서 영상 아이디어, 스토리라인, 비주얼 참조, 샷 구성을 기획할 수 있는 작은 화이트보드/무드보드 노드입니다.
+캔버스형 창작 워크스페이스에서 영감을 받았지만, 로컬에서 동작하며 일반적인 ComfyUI `IMAGE`로 내보냅니다.
 
-Inputs:
+입력:
 
-- `board_data`: serialized board JSON. The frontend hides this and keeps it synced from the inline board.
-- `width` / `height`: exported image size.
-- `background`: board background color, for example `#f4f1e8`.
+- `board_data`: 직렬화된 보드 JSON. 프런트엔드가 이를 숨기고 인라인 보드와 동기화 상태로 유지합니다.
+- `width` / `height`: 내보낼 이미지 크기.
+- `background`: 보드 배경색. 예: `#f4f1e8`.
 
-Inline board features:
+인라인 보드 기능:
 
-- The board is visible directly inside the node; there is no separate popup editor.
-- Drag image files directly onto the board to place them. Dropped images are embedded into `board_data`, so separate image input slots are not required.
-- Add text notes, rectangles, ellipses, arrows, and freehand pen strokes.
-- Select and drag items freely on the board.
-- Queueing the node exports the current board as an image.
+- 보드가 노드 안에 바로 보입니다. 별도의 팝업 편집기가 없습니다.
+- 이미지 파일을 보드 위로 바로 드래그해서 배치할 수 있습니다. 드롭한 이미지는 `board_data`에 임베드되므로 별도의 이미지 입력 슬롯이 필요 없습니다.
+- 텍스트 메모, 사각형, 타원, 화살표, 자유 곡선(펜) 추가.
+- 보드 위 항목을 자유롭게 선택·드래그.
+- 노드를 큐에 올리면 현재 보드를 이미지로 내보냅니다.
 
-Outputs:
+출력:
 
-- `image`: rendered board image.
-- `board_data`: saved board JSON for reuse or debugging.
+- `image`: 렌더링된 보드 이미지.
+- `board_data`: 재사용·디버깅용으로 저장된 보드 JSON.
 
 ### toobusy Z-Image Turbo
 
-Category:
+카테고리:
 
 ```text
 toobusy/Z-Image
 ```
 
-Folds a compact Z-Image Turbo text-to-image workflow into one node, without the final `SaveImage` node.
+컴팩트한 Z-Image Turbo 텍스트→이미지 워크플로우를 하나의 노드로 묶었습니다(마지막 `SaveImage` 노드는 제외).
 
-Internal flow:
+내부 흐름:
 
 ```text
 UNETLoader + CLIPLoader + VAELoader
--> optional LoraLoader slot chain
+-> 선택적 LoraLoader 슬롯 체인
 -> ModelSamplingAuraFlow
 -> CLIPTextEncode positive/negative
 -> EmptyLatentImage
@@ -163,23 +163,23 @@ UNETLoader + CLIPLoader + VAELoader
 -> VAEDecode
 ```
 
-Inputs include:
+주요 입력:
 
-- `model_name`: diffusion model/UNET file, for example `ZIT\zImage_turbo.safetensors`.
-- `clip_name`: text encoder file, for example `ZIT\zImage_textEncoder.safetensors`.
-- `vae_name`: VAE file, for example `FLUX1\ae.safetensors`.
-- `positive` / `negative`: prompt text.
-- `ratio_preset`, `megapixels`, `divisible_by`: resolution is calculated from aspect ratio and target megapixels.
+- `model_name`: 디퓨전 모델/UNET 파일. 예: `ZIT\zImage_turbo.safetensors`.
+- `clip_name`: 텍스트 인코더 파일. 예: `ZIT\zImage_textEncoder.safetensors`.
+- `vae_name`: VAE 파일. 예: `FLUX1\ae.safetensors`.
+- `positive` / `negative`: 프롬프트 텍스트.
+- `ratio_preset`, `megapixels`, `divisible_by`: 종횡비와 목표 메가픽셀로부터 해상도를 계산합니다.
 - `seed`, `steps`, `cfg`, `sampler_name`, `scheduler`, `denoise`, `aura_shift`.
-- LoRA slots: the frontend adds `Add LoRA slot` and `Remove LoRA slot` buttons. Up to 5 LoRA slots can be shown, and each slot has its own enable toggle, LoRA file, and strength.
+- LoRA 슬롯: 프런트엔드에 `Add LoRA slot` / `Remove LoRA slot` 버튼이 추가됩니다. 최대 5개 슬롯까지 표시할 수 있으며, 각 슬롯은 자체 활성화 토글, LoRA 파일, 강도를 가집니다.
 
-LoRA behavior:
+LoRA 동작:
 
-- Uses ComfyUI's built-in `LoraLoader`, so the rgthree Power Lora Loader is not required.
-- Enabled slots are applied in slot order.
-- Disabled slots and slots set to `None` are skipped.
+- ComfyUI 내장 `LoraLoader`를 사용하므로 rgthree의 Power Lora Loader가 필요 없습니다.
+- 활성화된 슬롯은 슬롯 순서대로 적용됩니다.
+- 비활성화된 슬롯과 `None`으로 설정된 슬롯은 건너뜁니다.
 
-Outputs:
+출력:
 
 - `image`
 - `latent`
@@ -188,15 +188,15 @@ Outputs:
 
 ### toobusy LTX2.3 Prompt Guide
 
-Category:
+카테고리:
 
 ```text
 toobusy/LTXV
 ```
 
-Folds prompt/negative encoding and LTX frame-rate conditioning into one node.
+프롬프트/네거티브 인코딩과 LTX 프레임레이트 컨디셔닝을 하나의 노드로 묶었습니다.
 
-Outputs:
+출력:
 
 - `positive`
 - `negative`
@@ -204,25 +204,25 @@ Outputs:
 - `frame_rate_float`
 - `length`
 
-`length` is calculated from `duration_seconds * frame_rate + 1`, so it can be connected directly to `toobusy LTX2.3 Empty AV Latents.length`.
+`length`는 `duration_seconds * frame_rate + 1`로 계산되므로 `toobusy LTX2.3 Empty AV Latents.length`에 바로 연결할 수 있습니다.
 
-Dialogue duration helper:
+대사 길이 도우미:
 
-- Quoted dialogue is detected with `'...'`, `"..."`, “...”, ‘...’, 「...」, and 『...』.
-- `Suggest duration` estimates duration from dialogue length.
-- `Apply recommended duration` copies the estimate into `duration_seconds`.
+- 인용된 대사는 `'...'`, `"..."`, “...”, ‘...’, 「...」, 『...』 형태로 감지합니다.
+- `Suggest duration`은 대사 길이로부터 소요 시간을 추정합니다.
+- `Apply recommended duration`은 추정값을 `duration_seconds`에 복사합니다.
 
 ### toobusy LTX2.3 Empty AV Latents
 
-Category:
+카테고리:
 
 ```text
 toobusy/LTXV
 ```
 
-Combines `EmptyLTXVLatentVideo` and `LTXVEmptyLatentAudio` into one node.
+`EmptyLTXVLatentVideo`와 `LTXVEmptyLatentAudio`를 하나의 노드로 결합합니다.
 
-Inputs include:
+주요 입력:
 
 - `audio_vae`
 - `ratio_preset`
@@ -232,12 +232,12 @@ Inputs include:
 - `frame_rate`
 - `batch_size`
 - `use_custom_audio`
-- optional `audio`
+- 선택적 `audio`
 
-The node calculates `width` and `height` from `ratio_preset * megapixels`, rounded to `divisible_by`.
+노드는 `ratio_preset * megapixels`로부터 `width`와 `height`를 계산하고 `divisible_by`에 맞춰 반올림합니다.
 
-When `use_custom_audio` is off, it creates empty audio latent with `LTXVEmptyLatentAudio`.
-When `use_custom_audio` is on, connect an `audio` input and it uses:
+`use_custom_audio`가 꺼져 있으면 `LTXVEmptyLatentAudio`로 빈 오디오 latent을 만듭니다.
+`use_custom_audio`가 켜져 있으면 `audio` 입력을 연결하고 다음을 사용합니다:
 
 ```text
 LTXVAudioVAEEncode -> SolidMask(0) -> SetLatentNoiseMask
@@ -245,19 +245,19 @@ LTXVAudioVAEEncode -> SolidMask(0) -> SetLatentNoiseMask
 
 ### toobusy LTX2.3 Compact AV Sampler
 
-Category:
+카테고리:
 
 ```text
 toobusy/LTXV
 ```
 
-Folds the common LTX2.3 AV sampling block into one node:
+자주 쓰는 LTX2.3 AV 샘플링 블록을 하나의 노드로 묶었습니다:
 
 ```text
 RandomNoise -> LTXVConcatAVLatent -> CFGGuider -> KSamplerSelect -> ManualSigmas/SIGMAS -> SamplerCustomAdvanced -> LTXVSeparateAVLatent -> LTXVCropGuides
 ```
 
-Inputs:
+입력:
 
 - `model`
 - `positive`
@@ -268,36 +268,35 @@ Inputs:
 - `cfg`
 - `sampler_name`
 - `manual_sigmas`
-- optional `sigmas`
+- 선택적 `sigmas`
 
-If `sigmas` is connected, the node uses that injected sigma schedule. Otherwise it uses `manual_sigmas`.
+`sigmas`가 연결되어 있으면 주입된 시그마 스케줄을 사용하고, 그렇지 않으면 `manual_sigmas`를 사용합니다.
 
-The node always runs `LTXVCropGuides` after sampling so guide frames are removed before the latent continues.
+노드는 샘플링 후 항상 `LTXVCropGuides`를 실행하여 latent이 이어지기 전에 가이드 프레임을 제거합니다.
 
-## Additional / Experimental Nodes
+## 추가 / 실험적 노드
 
-These nodes are also registered through `NODE_CLASS_MAPPINGS` (so they appear in
-the node menu), but are less polished than the core set above:
+아래 노드들도 `NODE_CLASS_MAPPINGS`를 통해 등록되어 있어 노드 메뉴에 나타나지만, 위의 핵심 노드들보다는 완성도가 낮습니다:
 
-- `hf_model_auto_loader` — auto-resolves/downloads Hugging Face model files.
-- `ideogram_layout_builder` (`toobusy Ideogram Layout Builder`) — a visual bbox
-  editor that emits an Ideogram 4 structured-prompt JSON plus `width`/`height`.
-  Draw regions on the canvas, mark each as text or object, set global/per-element
-  palettes, and wire the JSON into a text encoder. Per-element **roles**
-  (headline / subtitle / footer / product label / sign / logo …) expand into
-  description hints, **layout templates** (poster, product ad, packaging, UI,
-  infographic) seed a starting set of boxes, and three toggles control the
-  output: `strict_text` (faithful spelling hints), `reinforce_text` (repeat the
-  literal text in `desc`, off = compact JSON), and `include_global_palette`
-  (omit the global palette to leave color open).
-- `ideogram4_t2i_node` (`toobusy Ideogram4 T2I`) — runs a local Ideogram 4 model
-  (CLIP `ideogram4`, `Ideogram4Scheduler`) from a prompt; accepts the Layout
-  Builder's JSON prompt and `width`/`height` directly.
+- `hf_model_auto_loader` — Hugging Face 모델 파일을 자동으로 찾아주거나 다운로드합니다.
+- `ideogram_layout_builder` (`toobusy Ideogram Layout Builder`) — Ideogram 4
+  구조화 프롬프트 JSON과 `width`/`height`를 출력하는 시각적 bbox 편집기입니다.
+  캔버스에 영역을 그리고, 각 영역을 텍스트 또는 오브젝트로 지정하고, 전역/요소별
+  팔레트를 설정한 뒤 그 JSON을 텍스트 인코더로 연결합니다. 요소별 **역할(role)**
+  (headline / subtitle / footer / product label / sign / logo …)은 설명 힌트로
+  확장되고, **레이아웃 템플릿**(poster, product ad, packaging, UI, infographic)은
+  시작용 박스 세트를 깔아주며, 세 개의 토글이 출력을 제어합니다: `strict_text`
+  (정확한 철자 렌더링 힌트), `reinforce_text`(`desc`에 글자 그대로를 한 번 더
+  반복 — 끄면 컴팩트 JSON), `include_global_palette`(전역 팔레트를 생략해 색을
+  열어둠).
+- `ideogram4_t2i_node` (`toobusy Ideogram4 T2I`) — 프롬프트로부터 로컬 Ideogram 4
+  모델(CLIP `ideogram4`, `Ideogram4Scheduler`)을 실행합니다. Layout Builder의 JSON
+  프롬프트와 `width`/`height`를 그대로 받습니다.
 
-## Roadmap
+## 로드맵
 
-Near-term plan:
+단기 계획:
 
-1. Finish `toobusy Keyframe Maker` polish.
-2. Polish the compact Z-Image Turbo generation node.
-3. Prepare the repository for ComfyUI-Manager registration and public video release.
+1. `toobusy Keyframe Maker` 다듬기 마무리.
+2. 컴팩트 Z-Image Turbo 생성 노드 다듬기.
+3. ComfyUI-Manager 등록 및 공개 영상 릴리스를 위한 저장소 정비.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,13 @@ the node menu), but are less polished than the core set above:
 - `ideogram_layout_builder` (`toobusy Ideogram Layout Builder`) — a visual bbox
   editor that emits an Ideogram 4 structured-prompt JSON plus `width`/`height`.
   Draw regions on the canvas, mark each as text or object, set global/per-element
-  palettes, and wire the JSON into a text encoder.
+  palettes, and wire the JSON into a text encoder. Per-element **roles**
+  (headline / subtitle / footer / product label / sign / logo …) expand into
+  description hints, **layout templates** (poster, product ad, packaging, UI,
+  infographic) seed a starting set of boxes, and three toggles control the
+  output: `strict_text` (faithful spelling hints), `reinforce_text` (repeat the
+  literal text in `desc`, off = compact JSON), and `include_global_palette`
+  (omit the global palette to leave color open).
 - `ideogram4_t2i_node` (`toobusy Ideogram4 T2I`) — runs a local Ideogram 4 model
   (CLIP `ideogram4`, `Ideogram4Scheduler`) from a prompt; accepts the Layout
   Builder's JSON prompt and `width`/`height` directly.

--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -3,10 +3,9 @@ import re
 
 
 HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+# Keep in sync with MIN_BOX_SIZE in js/ideogram_layout_builder.js: the UI never
+# lets a box get smaller than this, so anything at this size is a real box.
 MIN_BOX_SIZE = 40
-# Boxes smaller than this in both dimensions are treated as stray/degenerate
-# (e.g. an accidental click box) and dropped from the output.
-DEGENERATE_BOX_SIZE = 48
 STYLE_PALETTE_MAX = 16
 ELEMENT_PALETTE_MAX = 5
 PLACEHOLDER_DESCS = {"", "new layout element", "layout element", "duplicated layout element"}
@@ -66,12 +65,13 @@ def _to_ideogram_bbox(value):
 def _is_placeholder_element(text, desc, bbox):
     width = bbox[2] - bbox[0]
     height = bbox[3] - bbox[1]
-    # Drop stray/degenerate boxes (tiny in both dimensions), e.g. an accidental
-    # click box that was never dragged into a real region.
-    if width < DEGENERATE_BOX_SIZE and height < DEGENERATE_BOX_SIZE:
-        return True
-    is_tiny_corner = bbox[0] == 0 and bbox[1] == 0 and width <= MIN_BOX_SIZE and height <= MIN_BOX_SIZE
-    return not text and desc.lower() in PLACEHOLDER_DESCS and is_tiny_corner
+    has_content = bool(text) or desc.lower() not in PLACEHOLDER_DESCS
+    # A box is "stray" only when it carries no real content AND is tiny in both
+    # dimensions (e.g. an accidental click box, or an empty default element that
+    # was never positioned). bbox is already grown to MIN_BOX_SIZE by
+    # _normalize_bbox, so a described box at the UI minimum is always kept.
+    is_tiny = width <= MIN_BOX_SIZE and height <= MIN_BOX_SIZE
+    return not has_content and is_tiny
 
 
 def _build_desc(text, desc):
@@ -91,11 +91,19 @@ def _element_type(text, desc):
 def _load_elements(elements_json):
     if not elements_json.strip():
         return []
-    data = json.loads(elements_json)
+    try:
+        data = json.loads(elements_json)
+    except (ValueError, TypeError):
+        # Malformed JSON (hand-edited or fed from another node) should not abort
+        # the whole graph; fall back to "no elements" and let build() emit its
+        # default centered subject.
+        print("[toobusy ideogram] elements_json is not valid JSON; ignoring it.")
+        return []
     if isinstance(data, dict):
         data = data.get("elements", [])
     if not isinstance(data, list):
-        raise ValueError("elements_json must be a JSON array or an object with an elements array.")
+        print("[toobusy ideogram] elements_json must be a JSON array or an object with an 'elements' array; ignoring it.")
+        return []
     return data
 
 

--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -10,6 +10,25 @@ STYLE_PALETTE_MAX = 16
 ELEMENT_PALETTE_MAX = 5
 PLACEHOLDER_DESCS = {"", "new layout element", "layout element", "duplicated layout element"}
 
+# Optional role hint appended to an element's description. Keep keys in sync with
+# ROLE_PRESETS in js/ideogram_layout_builder.js.
+ROLE_HINTS = {
+    "headline": "large bold headline typography, dominant in the layout",
+    "subtitle": "secondary subtitle text, smaller than the headline",
+    "body": "body copy, evenly spaced and comfortably readable",
+    "footer": "small footer text near the edge of the composition",
+    "product label": "label text printed on the product surface",
+    "sign": "sign text, legible despite perspective and reflections",
+    "ui label": "small UI label text, crisp and precisely aligned",
+    "logo": "logo / wordmark, clean and balanced",
+}
+
+# Appended to text elements when strict_text is on, to push faithful rendering.
+STRICT_TEXT_HINTS = (
+    "spelled exactly as written, sharp and readable, no extra or missing "
+    "letters, preserve capitalization and punctuation"
+)
+
 
 def _parse_palette(value, fallback=None, limit=ELEMENT_PALETTE_MAX):
     fallback = fallback or []
@@ -74,14 +93,40 @@ def _is_placeholder_element(text, desc, bbox):
     return not has_content and is_tiny
 
 
-def _build_desc(text, desc):
+def _build_desc(text, desc, role="", strict_text=False, reinforce_text=True):
     if desc.lower() in PLACEHOLDER_DESCS:
         desc = ""
-    if text and desc:
-        return desc if text.lower() in desc.lower() else f"{desc} Text reads '{text}'."
-    if text:
-        return f"clean rendered text integrated into the composition, text reads '{text}'"
-    return desc or "layout element"
+    role_hint = ROLE_HINTS.get(role.strip().lower(), "") if role else ""
+
+    if not text:
+        # Object element: description plus an optional role hint (e.g. a logo
+        # placed as an object rather than literal text).
+        clauses = [c for c in (desc, role_hint) if c]
+        return ". ".join(clauses) if clauses else "layout element"
+
+    # Text element.
+    clauses = []
+    if desc and text.lower() in desc.lower():
+        # The user already wrote the literal text into the description; trust it
+        # and only layer on the role hint.
+        clauses.append(desc)
+        if role_hint:
+            clauses.append(role_hint)
+    else:
+        if desc:
+            clauses.append(desc)
+        if role_hint:
+            clauses.append(role_hint)
+        if reinforce_text:
+            clauses.append(f"text reads '{text}'")
+    if not clauses:
+        base = "clean rendered text integrated into the composition"
+        if reinforce_text:
+            base += f", text reads '{text}'"
+        clauses.append(base)
+    if strict_text:
+        clauses.append(STRICT_TEXT_HINTS)
+    return ". ".join(clauses)
 
 
 def _element_type(text, desc):
@@ -152,6 +197,30 @@ class IdeogramLayoutBuilder:
                         "default": "#111111, #FFFFFF, #D8C7A3",
                     },
                 ),
+                "include_global_palette": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "label_on": "use global palette",
+                        "label_off": "omit global palette",
+                    },
+                ),
+                "strict_text": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "label_on": "strict text rendering",
+                        "label_off": "relaxed text",
+                    },
+                ),
+                "reinforce_text": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "label_on": "reinforce text (reads '...')",
+                        "label_off": "compact JSON",
+                    },
+                ),
                 "background": (
                     "STRING",
                     {
@@ -204,6 +273,9 @@ class IdeogramLayoutBuilder:
         elements_json,
         width,
         height,
+        include_global_palette=True,
+        strict_text=True,
+        reinforce_text=True,
     ):
         elements = []
         for item in _load_elements(elements_json):
@@ -212,6 +284,7 @@ class IdeogramLayoutBuilder:
             bbox = _normalize_bbox(item.get("bbox"))
             text = str(item.get("text", "")).strip()
             desc = str(item.get("desc", "")).strip()
+            role = str(item.get("role", "")).strip()
             if _is_placeholder_element(text, desc, bbox):
                 continue
 
@@ -228,7 +301,9 @@ class IdeogramLayoutBuilder:
             element = {"type": element_type, "bbox": ideogram_bbox}
             if element_type == "text":
                 element["text"] = text
-            element["desc"] = _build_desc(text, desc)
+            element["desc"] = _build_desc(
+                text, desc, role=role, strict_text=strict_text, reinforce_text=reinforce_text
+            )
             if palette:
                 element["color_palette"] = palette
             elements.append(element)
@@ -247,17 +322,23 @@ class IdeogramLayoutBuilder:
                 }
             )
 
+        style_description = {
+            "aesthetics": aesthetics.strip(),
+            "lighting": lighting.strip(),
+            "photo": photo.strip(),
+            "medium": medium.strip(),
+        }
+        # Only attach a global color_palette when the user opted in. Omitting it
+        # lets color conditioning be left intentionally open (color_palette is
+        # the last key, so dropping it keeps the documented key order intact).
+        if include_global_palette:
+            style_description["color_palette"] = _parse_palette(
+                global_palette, ["#111111", "#FFFFFF", "#D8C7A3"], limit=STYLE_PALETTE_MAX
+            )
+
         payload = {
             "high_level_description": high_level_description.strip(),
-            "style_description": {
-                "aesthetics": aesthetics.strip(),
-                "lighting": lighting.strip(),
-                "photo": photo.strip(),
-                "medium": medium.strip(),
-                "color_palette": _parse_palette(
-                    global_palette, ["#111111", "#FFFFFF", "#D8C7A3"], limit=STYLE_PALETTE_MAX
-                ),
-            },
+            "style_description": style_description,
             "compositional_deconstruction": {
                 "background": background.strip(),
                 "elements": elements,

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -465,6 +465,42 @@ function installEditor(node) {
                 color: #9fb0c0;
                 font-size: 11px;
             }
+            .toobusy-ideogram .layer-list {
+                display: flex;
+                flex-direction: column;
+                gap: 3px;
+                max-height: 220px;
+                overflow-y: auto;
+            }
+            .toobusy-ideogram .layer-row {
+                display: flex;
+                gap: 2px;
+                align-items: center;
+            }
+            .toobusy-ideogram .layer-row.active .layer-name {
+                border-color: #6f93c8;
+                background: #1d2733;
+                color: #ffffff;
+            }
+            .toobusy-ideogram .layer-name {
+                flex: 1 1 auto;
+                min-width: 0;
+                text-align: left;
+                padding: 3px 6px;
+                font-size: 11px;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+            .toobusy-ideogram .layer-btn {
+                flex: 0 0 auto;
+                width: 22px;
+                height: 24px;
+                padding: 0;
+                font-size: 10px;
+                line-height: 1;
+            }
+            .toobusy-ideogram .layer-btn:disabled { opacity: 0.35; cursor: default; }
             .toobusy-ideogram .canvas-frame {
                 width: 100%;
                 height: 360px;
@@ -798,6 +834,7 @@ function installEditor(node) {
 
     function renderElementPanel() {
         elementPanel.replaceChildren();
+        renderLayerList();
         const heading = document.createElement("div");
         heading.className = "section-title";
         heading.textContent = "Selected element";
@@ -1116,11 +1153,84 @@ function installEditor(node) {
     sideTitle.textContent = "Info";
     const countReadout = document.createElement("div");
     countReadout.className = "count-readout";
-    sideInfo.append(sideTitle, countReadout, bboxReadout);
+    const layerTitle = document.createElement("div");
+    layerTitle.className = "section-title";
+    layerTitle.textContent = "Layers";
+    const layerList = document.createElement("div");
+    layerList.className = "layer-list";
+    sideInfo.append(sideTitle, countReadout, bboxReadout, layerTitle, layerList);
     updateCount = () => {
         countReadout.textContent = `${elements.length} box(es)`;
     };
     updateCount();
+
+    // Top-most box is drawn last (highest index); show the list top-to-bottom in
+    // that visual stacking order so clicking a row picks even an occluded box.
+    function renderLayerList() {
+        if (!layerList) return;
+        layerList.replaceChildren();
+        if (!elements.length) {
+            const empty = document.createElement("div");
+            empty.className = "panel-empty";
+            empty.textContent = "No boxes yet.";
+            layerList.appendChild(empty);
+            return;
+        }
+        for (let i = elements.length - 1; i >= 0; i--) {
+            const el = elements[i];
+            const row = document.createElement("div");
+            row.className = "layer-row" + (i === selectedIndex ? " active" : "");
+
+            const isText = !!(el.text && el.text.trim());
+            const label = `${isText ? "T" : "□"} ${el.text || el.desc || `Element ${i + 1}`}`;
+            const name = makeButton(label, "Select this box", () => {
+                selectedIndex = i;
+                renderElementPanel();
+            });
+            name.classList.add("layer-name");
+
+            const raise = makeButton("▲", "Bring forward", () => raiseElement(i));
+            const lower = makeButton("▼", "Send backward", () => lowerElement(i));
+            const del = makeButton("✕", "Delete this box", () => {
+                selectedIndex = i;
+                deleteElement();
+            });
+            for (const b of [raise, lower, del]) b.classList.add("layer-btn");
+            if (i === elements.length - 1) raise.disabled = true;
+            if (i === 0) lower.disabled = true;
+
+            row.append(name, raise, lower, del);
+            layerList.appendChild(row);
+        }
+    }
+
+    // z-order helpers: swapping array position changes draw/hit-test stacking.
+    function swapElements(a, b) {
+        if (a < 0 || b < 0 || a >= elements.length || b >= elements.length) return;
+        [elements[a], elements[b]] = [elements[b], elements[a]];
+        if (selectedIndex === a) selectedIndex = b;
+        else if (selectedIndex === b) selectedIndex = a;
+        syncElements();
+        renderElementPanel();
+        draw();
+    }
+    function raiseElement(i) { swapElements(i, i + 1); }
+    function lowerElement(i) { swapElements(i, i - 1); }
+
+    // Nudge the selected box by (dx, dy), keeping its size and staying in bounds.
+    function nudgeSelected(dx, dy) {
+        const el = selected();
+        if (!el) return;
+        const w = el.bbox[2] - el.bbox[0];
+        const h = el.bbox[3] - el.bbox[1];
+        el.bbox[0] = clamp(el.bbox[0] + dx, 0, CANVAS_SIZE - w);
+        el.bbox[1] = clamp(el.bbox[1] + dy, 0, CANVAS_SIZE - h);
+        el.bbox[2] = el.bbox[0] + w;
+        el.bbox[3] = el.bbox[1] + h;
+        bboxReadout.textContent = `bbox: [${el.bbox.join(", ")}]`;
+        syncElements();
+        draw();
+    }
 
     // ----- Presets (saved in the browser via localStorage) -----
     const PRESET_STORE_KEY = "toobusy.ideogram.presets";
@@ -1263,7 +1373,12 @@ function installEditor(node) {
 
     const DRAG_THRESHOLD = 28; // normalized units before an empty-canvas drag becomes a new box
 
+    // Make the canvas focusable so it can receive keyboard shortcuts.
+    canvas.tabIndex = 0;
+    canvas.style.outline = "none";
+
     canvas.addEventListener("pointerdown", (event) => {
+        canvas.focus();
         const pos = point(event);
         const hit = hitTest(pos);
         if (hit.index >= 0) {
@@ -1366,6 +1481,34 @@ function installEditor(node) {
         } else if (mode === "create") {
             syncElements();
             renderElementPanel();
+        }
+    });
+
+    // Keyboard shortcuts while the canvas is focused: Delete/Backspace removes
+    // the selected box, arrows nudge it (Shift = larger step), Esc deselects.
+    canvas.addEventListener("keydown", (event) => {
+        if (event.key === "Delete" || event.key === "Backspace") {
+            if (selectedIndex < 0) return;
+            event.preventDefault();
+            deleteElement();
+            return;
+        }
+        if (event.key === "Escape") {
+            if (selectedIndex < 0) return;
+            event.preventDefault();
+            selectedIndex = -1;
+            renderElementPanel();
+            return;
+        }
+        const step = event.shiftKey ? 20 : 5;
+        const nudges = {
+            ArrowUp: [0, -step], ArrowDown: [0, step],
+            ArrowLeft: [-step, 0], ArrowRight: [step, 0],
+        };
+        if (nudges[event.key]) {
+            if (selectedIndex < 0) return;
+            event.preventDefault();
+            nudgeSelected(nudges[event.key][0], nudges[event.key][1]);
         }
     });
 

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -61,6 +61,62 @@ const PALETTE_PRESETS = [
     ["High contrast", ["#000000", "#FFFFFF", "#FF3B30", "#FFD60A", "#0A84FF"]],
 ];
 
+// Text element roles. Value is sent as `role` on each element; the Python node
+// expands it into a description hint (keep keys in sync with ROLE_HINTS).
+const ROLE_PRESETS = [
+    ["None", ""],
+    ["Headline", "headline"],
+    ["Subtitle", "subtitle"],
+    ["Body", "body"],
+    ["Footer", "footer"],
+    ["Product label", "product label"],
+    ["Sign", "sign"],
+    ["UI label", "ui label"],
+    ["Logo / wordmark", "logo"],
+];
+
+// One-click starting layouts. bbox is [x_min, y_min, x_max, y_max] on the
+// 0-1000 canvas; text + role + desc seed each region (desc left blank so the
+// user fills the specifics).
+const LAYOUT_TEMPLATES = [
+    ["(template…)", null],
+    ["Poster", [
+        { bbox: [120, 90, 880, 240], text: "HEADLINE", role: "headline" },
+        { bbox: [120, 250, 880, 340], text: "Subtitle goes here", role: "subtitle" },
+        { bbox: [200, 380, 800, 820], text: "", role: "", desc: "hero subject" },
+        { bbox: [120, 900, 880, 960], text: "footer / website", role: "footer" },
+    ]],
+    ["Product ad", [
+        { bbox: [300, 120, 700, 620], text: "", role: "", desc: "hero product" },
+        { bbox: [100, 660, 900, 780], text: "HEADLINE", role: "headline" },
+        { bbox: [150, 790, 850, 860], text: "supporting claim", role: "subtitle" },
+        { bbox: [410, 890, 590, 960], text: "LOGO", role: "logo" },
+    ]],
+    ["Packaging label", [
+        { bbox: [380, 80, 620, 200], text: "LOGO", role: "logo" },
+        { bbox: [120, 240, 880, 380], text: "PRODUCT TITLE", role: "headline" },
+        { bbox: [160, 410, 840, 520], text: "descriptor", role: "subtitle" },
+        { bbox: [380, 820, 620, 920], text: "500ml", role: "product label" },
+    ]],
+    ["UI screenshot", [
+        { bbox: [40, 40, 240, 960], text: "", role: "", desc: "sidebar navigation" },
+        { bbox: [280, 40, 960, 130], text: "Dashboard", role: "ui label" },
+        { bbox: [280, 160, 470, 360], text: "", role: "", desc: "KPI card" },
+        { bbox: [500, 160, 690, 360], text: "", role: "", desc: "KPI card" },
+        { bbox: [720, 160, 960, 360], text: "", role: "", desc: "KPI card" },
+        { bbox: [280, 390, 960, 760], text: "", role: "", desc: "main graph" },
+        { bbox: [280, 790, 960, 960], text: "", role: "", desc: "activity panel" },
+    ]],
+    ["Infographic", [
+        { bbox: [120, 70, 880, 190], text: "TITLE", role: "headline" },
+        { bbox: [60, 260, 250, 520], text: "Step 1", role: "subtitle" },
+        { bbox: [280, 260, 470, 520], text: "Step 2", role: "subtitle" },
+        { bbox: [500, 260, 690, 520], text: "Step 3", role: "subtitle" },
+        { bbox: [720, 260, 940, 520], text: "Step 4", role: "subtitle" },
+        { bbox: [120, 600, 880, 920], text: "", role: "", desc: "summary / chart" },
+    ]],
+];
+
 const COLOR_CHOICES = [
     "#000000",
     "#111111",
@@ -121,6 +177,7 @@ function normalizeElement(element = {}, index = 0) {
         bbox,
         text: element.text || "",
         desc: element.desc || "",
+        role: typeof element.role === "string" ? element.role : "",
         color_palette: Array.isArray(element.color_palette) ? element.color_palette : [],
     };
 }
@@ -208,6 +265,23 @@ function makeSelectField(labelText, options, currentValue, onInput) {
     select.value = currentValue || options[0][1];
     select.addEventListener("change", () => onInput(select.value));
     label.append(span, select);
+    return label;
+}
+
+function makeCheckboxField(labelText, checked, onInput, title = "") {
+    const label = document.createElement("label");
+    label.className = "checkbox-field";
+    if (title) label.title = title;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.id = uid("check");
+    input.name = input.id;
+    input.checked = !!checked;
+    const span = document.createElement("span");
+    span.textContent = labelText;
+    span.htmlFor = input.id;
+    input.addEventListener("change", () => onInput(input.checked));
+    label.append(input, span);
     return label;
 }
 
@@ -417,6 +491,23 @@ function installEditor(node) {
                 gap: 3px;
                 color: #aeb8c4;
                 min-width: 0;
+            }
+            .toobusy-ideogram label.checkbox-field {
+                flex-direction: row;
+                align-items: center;
+                gap: 7px;
+                cursor: pointer;
+            }
+            .toobusy-ideogram label.checkbox-field input {
+                width: auto;
+                flex: 0 0 auto;
+                margin: 0;
+                cursor: pointer;
+            }
+            .toobusy-ideogram .output-options {
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
             }
             .toobusy-ideogram input,
             .toobusy-ideogram select,
@@ -758,6 +849,16 @@ function installEditor(node) {
                 },
                 "Type to render this box as text. Leave blank for an object.",
             ),
+            makeSelectField(
+                "Role (text hint)",
+                ROLE_PRESETS,
+                element.role || "",
+                (value) => {
+                    element.role = value;
+                    syncElements();
+                    draw();
+                },
+            ),
             makeField(
                 "Description",
                 element.desc,
@@ -896,6 +997,65 @@ function installEditor(node) {
     palettePresetWrap.append(palettePresetLabel, globalPalette.root);
     scene.appendChild(palettePresetWrap);
 
+    // ----- Output / text options (drive the hidden BOOLEAN widgets) -----
+    const outputTitle = document.createElement("div");
+    outputTitle.className = "section-title";
+    outputTitle.textContent = "Text & output";
+    const outputOptions = document.createElement("div");
+    outputOptions.className = "output-options";
+    const includePaletteField = makeCheckboxField(
+        "Include global palette",
+        widget(node, "include_global_palette")?.value ?? true,
+        (checked) => syncScene("include_global_palette", checked),
+        "When off, the global color_palette is omitted so color is left open.",
+    );
+    const strictTextField = makeCheckboxField(
+        "Strict text rendering",
+        widget(node, "strict_text")?.value ?? true,
+        (checked) => syncScene("strict_text", checked),
+        "Adds 'spelled exactly, sharp, preserve caps/punctuation' to text elements.",
+    );
+    const reinforceTextField = makeCheckboxField(
+        "Reinforce text (“reads ...”)",
+        widget(node, "reinforce_text")?.value ?? true,
+        (checked) => syncScene("reinforce_text", checked),
+        "Off = compact JSON: rely on the text field without repeating it in desc.",
+    );
+    // Map each toggle widget to its checkbox so presets can refresh the view.
+    const toggleInputs = {
+        include_global_palette: includePaletteField.querySelector("input"),
+        strict_text: strictTextField.querySelector("input"),
+        reinforce_text: reinforceTextField.querySelector("input"),
+    };
+    outputOptions.append(includePaletteField, strictTextField, reinforceTextField);
+    scene.append(outputTitle, outputOptions);
+
+    // ----- Layout templates (seed a starting set of boxes) -----
+    function applyTemplate(elementSeeds) {
+        elements = elementSeeds.map((seed, index) => normalizeElement(seed, index));
+        selectedIndex = elements.length ? 0 : -1;
+        syncElements();
+        renderElementPanel();
+        draw();
+    }
+    const templateField = makeSelectField(
+        "Layout template",
+        LAYOUT_TEMPLATES.map(([name]) => [name, name]),
+        LAYOUT_TEMPLATES[0][0],
+        (name) => {
+            const tpl = LAYOUT_TEMPLATES.find(([n]) => n === name);
+            if (!tpl || !tpl[1]) return;
+            const ok = !elements.length || window.confirm("Replace the current boxes with this template?");
+            if (ok) applyTemplate(tpl[1]);
+            // Reset back to the placeholder option so re-picking the same template works.
+            templateField.querySelector("select").value = LAYOUT_TEMPLATES[0][0];
+        },
+    );
+    const templateTitle = document.createElement("div");
+    templateTitle.className = "section-title";
+    templateTitle.textContent = "Start";
+    scene.prepend(templateTitle, templateField);
+
     const presetLabel = document.createElement("label");
     const presetTitle = document.createElement("span");
     const presetSelect = document.createElement("select");
@@ -1009,6 +1169,9 @@ function installEditor(node) {
             medium: widget(node, "medium")?.value || "",
             global_palette: widget(node, "global_palette")?.value || "",
             background: widget(node, "background")?.value || "",
+            include_global_palette: widget(node, "include_global_palette")?.value ?? true,
+            strict_text: widget(node, "strict_text")?.value ?? true,
+            reinforce_text: widget(node, "reinforce_text")?.value ?? true,
             elements: JSON.parse(JSON.stringify(elements)),
             resolution: { ...resolution },
         };
@@ -1038,6 +1201,16 @@ function installEditor(node) {
                 sw.dataset.color = c;
             });
         }
+
+        const setToggle = (name, value) => {
+            if (value === undefined) return;
+            syncScene(name, !!value);
+            const input = toggleInputs[name];
+            if (input) input.checked = !!value;
+        };
+        setToggle("include_global_palette", state.include_global_palette);
+        setToggle("strict_text", state.strict_text);
+        setToggle("reinforce_text", state.reinforce_text);
 
         if (Array.isArray(state.elements)) {
             elements = state.elements.map(normalizeElement);

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -220,7 +220,22 @@ function makeNumberInput(value, onInput) {
     input.max = "2048";
     input.step = "1";
     input.value = String(value);
-    input.addEventListener("input", () => onInput(clamp(input.value, 256, 2048)));
+    // Clamp on commit (blur / Enter), not on every keystroke: clamping mid-typing
+    // turns a partial "1" into 256, flips the preset to custom, and triggers a
+    // canvas redraw on each character. On commit, also write the clamped value
+    // back so the field never shows an out-of-range number.
+    const commit = () => {
+        const clamped = clamp(input.value, 256, 2048);
+        input.value = String(clamped);
+        onInput(clamped);
+    };
+    input.addEventListener("change", commit);
+    input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            input.blur();
+        }
+    });
     return input;
 }
 


### PR DESCRIPTION
Ideogram Layout Builder 개선 묶음입니다.

### 1. 동작 결함 수정 (`69dfd8c`)
- **박스 크기 버그**: 양변 모두 40~47px인, 사용자가 실제로 그린 박스를 조용히 버리던 `DEGENERATE_BOX_SIZE`(48) 필터 제거. 이제 박스는 *실제 내용이 없고(빈 텍스트 + 플레이스홀더 desc)* UI 최소 크기 이하일 때만 stray로 간주 → 설명/텍스트가 있는 박스는 항상 보존.
- **JSON 안전성**: `_load_elements`가 깨진/비배열 `elements_json`에 대해 더 이상 예외를 던지지 않고 로그 후 `[]`로 폴백 → 잘못된 입력이 워크플로우 전체를 멈추지 않음.
- **해상도 입력**: width/height 숫자 입력을 매 키 입력이 아니라 commit(change/Enter) 시점에 클램프하고 클램프된 값을 필드에 되씀 → 타이핑 중 256으로 튀던 문제 해결.
- **README**: 실제로는 등록되어 있는 노드들을 "hidden experimental"이라 적던 낡은 설명 정정, 두 Ideogram 노드 문서화.

### 2. 프롬프트 품질 보조 (`6a746c0`)
- 요소별 **역할(role)** → 설명 힌트 확장 (headline/subtitle/footer/product label/sign/logo …).
- **`strict_text` / `reinforce_text` / `include_global_palette`** 토글 (정확 철자 힌트, compact vs reinforced JSON, 전역 팔레트 선택적 포함).
- **레이아웃 템플릿** (poster / product ad / packaging / UI / infographic) 한 번에 박스 배치.

### 3. README 한글화 (`1c5ec4e`)
- 노드명·카테고리·코드블록·식별자는 유지하고 설명문 전체를 한국어로 번역.

### 4. 편집 UX (`0f750d9`)
- **키보드 단축키**(캔버스 포커스 시): Delete/Backspace 선택 박스 삭제, 방향키 이동(Shift = 20, 기본 5), Esc 선택 해제.
- **레이어 리스트**: 스택 순서대로 박스 한 줄씩 표시 → 가려진 박스도 클릭해 선택. 행마다 앞으로/뒤로(z-order) + 삭제.

### 검증
- backend는 `build()`를 박스 크기 / 역할 / 토글 / 팔레트 / 깨진 JSON / 하위호환 케이스로 직접 실행해 확인.
- JS는 정적 검토 + 괄호 균형 체크 (로컬에 node 미설치) — ComfyUI에서 실제 구동 검증은 아직.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
