### PR TITLE
Storyboard Board 편집 스위트 + 프리뷰 래핑 (P3 #8/#9)

### DIFF
--- a/js/toobusy_storyboard_board.js
+++ b/js/toobusy_storyboard_board.js
@@ -7,6 +7,9 @@ const DEFAULT_BOARD = {
     ],
 };
 
+const HANDLE = 10; // resize handle size in canvas pixels
+const MIN_SIZE = 20;
+
 function findWidget(node, name) {
     return node.widgets?.find((widget) => widget.name === name);
 }
@@ -25,12 +28,16 @@ function parseBoard(node) {
     return structuredClone(DEFAULT_BOARD);
 }
 
+function serializeBoard(board) {
+    // Skip the back-reference to the ComfyNode, otherwise JSON.stringify hits a
+    // circular structure (node -> widgets -> DOMWidget._node).
+    return JSON.stringify(board, (key, value) => (key === "_node" ? undefined : value));
+}
+
 function saveBoard(node, board) {
     const widget = boardWidget(node);
     if (widget) {
-        // Skip the back-reference to the ComfyNode, otherwise JSON.stringify hits
-        // a circular structure (node -> widgets -> DOMWidget._node).
-        widget.value = JSON.stringify(board, (key, value) => (key === "_node" ? undefined : value));
+        widget.value = serializeBoard(board);
     }
     node.setDirtyCanvas?.(true, true);
     app.graph?.setDirtyCanvas?.(true, true);
@@ -84,6 +91,24 @@ function hitItem(board, point) {
     return null;
 }
 
+function near(point, x, y) {
+    return Math.abs(point.x - x) <= HANDLE && Math.abs(point.y - y) <= HANDLE;
+}
+
+// Returns a drag descriptor if the point grabs a handle of the selected item.
+function handleAt(item, point) {
+    if (!item) return null;
+    if (item.type === "line") {
+        if (near(point, item.x, item.y)) return { mode: "line-end", end: "start" };
+        if (near(point, item.x2, item.y2)) return { mode: "line-end", end: "end" };
+        return null;
+    }
+    if (item.type === "pen") return null; // freehand strokes are not resized
+    const b = itemBounds(item);
+    if (near(point, b.x + b.w, b.y + b.h)) return { mode: "resize" };
+    return null;
+}
+
 function addItem(board, type, point = { x: 120, y: 120 }) {
     const item = {
         id: crypto.randomUUID(),
@@ -118,6 +143,30 @@ function imageFromSrc(src, cache, onload) {
     img.src = src;
     cache.set(src, img);
     return img;
+}
+
+// Word-wrap to mirror storyboard_board.py _wrap_text: split on whitespace
+// (explicit newlines collapse to spaces, like Python's str.split()), keep a word
+// on the line while the measured width stays within `width`.
+function wrapTextLines(ctx, text, fontPx, width) {
+    ctx.font = `${fontPx}px sans-serif`;
+    const words = String(text || "").split(/\s+/).filter(Boolean);
+    if (!words.length) {
+        return [""];
+    }
+    const lines = [];
+    let current = words[0];
+    for (let i = 1; i < words.length; i += 1) {
+        const test = `${current} ${words[i]}`;
+        if (ctx.measureText(test).width <= width) {
+            current = test;
+        } else {
+            lines.push(current);
+            current = words[i];
+        }
+    }
+    lines.push(current);
+    return lines;
 }
 
 function drawBoard(ctx, board, selected, imageCache) {
@@ -186,10 +235,17 @@ function drawBoard(ctx, board, selected, imageCache) {
             ctx.stroke();
         } else if (item.type === "text") {
             ctx.fillStyle = item.color || "#111111";
-            ctx.font = `${item.fontSize || 24}px sans-serif`;
-            String(item.text || "").split("\n").forEach((line, index) => {
-                ctx.fillText(line, item.x, item.y + (item.fontSize || 24) * (index + 1));
-            });
+            const fs = item.fontSize || 24;
+            ctx.textBaseline = "top";
+            const lines = wrapTextLines(ctx, item.text, fs, Math.max(MIN_SIZE, item.w || MIN_SIZE));
+            let lineY = item.y;
+            for (const line of lines) {
+                ctx.fillText(line, item.x, lineY);
+                lineY += fs + 6; // mirror Python's per-line advance (~bbox height + 6)
+                if (lineY > item.y + (item.h || 0)) {
+                    break;
+                }
+            }
         }
 
         if (selected?.id === item.id) {
@@ -198,6 +254,17 @@ function drawBoard(ctx, board, selected, imageCache) {
             ctx.lineWidth = 2;
             ctx.setLineDash([6, 4]);
             ctx.strokeRect(bounds.x - 4, bounds.y - 4, bounds.w + 8, bounds.h + 8);
+
+            // Resize handles.
+            ctx.setLineDash([]);
+            ctx.fillStyle = "#2d7ff9";
+            if (item.type === "line") {
+                for (const [hx, hy] of [[item.x, item.y], [item.x2, item.y2]]) {
+                    ctx.fillRect(hx - HANDLE / 2, hy - HANDLE / 2, HANDLE, HANDLE);
+                }
+            } else if (item.type !== "pen") {
+                ctx.fillRect(bounds.x + bounds.w - HANDLE / 2, bounds.y + bounds.h - HANDLE / 2, HANDLE, HANDLE);
+            }
         }
         ctx.restore();
     }
@@ -212,15 +279,29 @@ function fileToDataUrl(file) {
     });
 }
 
+function rgbToHex(value) {
+    const match = String(value || "").match(/\d+(\.\d+)?/g);
+    if (!match || match.length < 3) {
+        return /^#[0-9a-f]{6}$/i.test(value) ? value : "#ffffff";
+    }
+    const [r, g, b] = match.map((n) => Math.max(0, Math.min(255, Math.round(parseFloat(n)))));
+    return `#${[r, g, b].map((n) => n.toString(16).padStart(2, "0")).join("")}`;
+}
+
 function makeInlineBoard(node) {
     const board = parseBoard(node);
     board._node = node;
     let selected = null;
     let tool = "select";
     let dragging = false;
+    let dragMode = "move"; // move | resize | line-end | pen
+    let dragEnd = null; // for line-end: "start" | "end"
     let penItem = null;
     let dragOffset = { x: 0, y: 0 };
     const imageCache = new Map();
+
+    const undoStack = [];
+    const redoStack = [];
 
     const root = document.createElement("div");
     root.style.cssText = "width:640px;background:#151915;color:#edf4ed;border:1px solid #3d543f;padding:6px;box-sizing:border-box;";
@@ -229,14 +310,19 @@ function makeInlineBoard(node) {
     toolbar.style.cssText = "display:flex;gap:4px;align-items:center;margin-bottom:6px;flex-wrap:wrap;";
     root.appendChild(toolbar);
 
+    const propBar = document.createElement("div");
+    propBar.style.cssText = "display:flex;gap:6px;align-items:center;margin-bottom:6px;flex-wrap:wrap;min-height:24px;";
+    root.appendChild(propBar);
+
     const canvas = document.createElement("canvas");
     canvas.width = 640;
     canvas.height = 360;
-    canvas.style.cssText = "display:block;width:100%;height:auto;background:#f4f1e8;cursor:crosshair;border:1px solid #384338;box-sizing:border-box;";
+    canvas.tabIndex = 0;
+    canvas.style.cssText = "display:block;width:100%;height:auto;background:#f4f1e8;cursor:crosshair;border:1px solid #384338;box-sizing:border-box;outline:none;";
     root.appendChild(canvas);
 
     const status = document.createElement("div");
-    status.textContent = "Drop images directly on the board.";
+    status.textContent = "Drop images directly on the board. Double-click text to edit.";
     status.style.cssText = "font-size:11px;color:#b8c7b8;margin-top:5px;";
     root.appendChild(status);
 
@@ -246,56 +332,246 @@ function makeInlineBoard(node) {
         saveBoard(node, board);
     };
 
-    const button = (label, action) => {
+    // ----- history -----
+    const snapshot = () => serializeBoard(board);
+    const pushHistory = () => {
+        undoStack.push(snapshot());
+        if (undoStack.length > 60) undoStack.shift();
+        redoStack.length = 0;
+    };
+    const restore = (snap) => {
+        try {
+            const data = JSON.parse(snap);
+            if (Array.isArray(data.items)) {
+                board.items = data.items;
+                selected = null;
+            }
+        } catch {}
+    };
+    const undo = () => {
+        if (!undoStack.length) return;
+        redoStack.push(snapshot());
+        restore(undoStack.pop());
+        renderProps();
+        redraw();
+    };
+    const redo = () => {
+        if (!redoStack.length) return;
+        undoStack.push(snapshot());
+        restore(redoStack.pop());
+        renderProps();
+        redraw();
+    };
+
+    const button = (label, action, parent = toolbar) => {
         const el = document.createElement("button");
         el.textContent = label;
         el.style.cssText = "background:#253126;color:#f0f6ef;border:1px solid #638266;padding:4px 7px;font-size:11px;cursor:pointer;";
         el.onclick = action;
-        toolbar.appendChild(el);
+        parent.appendChild(el);
+        return el;
+    };
+
+    const labelText = (text) => {
+        const el = document.createElement("span");
+        el.textContent = text;
+        el.style.cssText = "font-size:11px;color:#b8c7b8;";
         return el;
     };
 
     const select = (item) => {
         selected = item;
-        status.textContent = item ? `Selected: ${item.type}` : "Drop images directly on the board.";
+        status.textContent = item
+            ? `Selected: ${item.type}`
+            : "Drop images directly on the board. Double-click text to edit.";
+        renderProps();
         redraw();
     };
 
+    // ----- selected-item property controls -----
+    function renderProps() {
+        propBar.replaceChildren();
+        if (!selected) {
+            propBar.appendChild(labelText("No selection · pick a tool or click an item"));
+            return;
+        }
+        const item = selected;
+
+        // Stroke / text color (all items).
+        const colorInput = document.createElement("input");
+        colorInput.type = "color";
+        colorInput.value = rgbToHex(item.color || "#111111");
+        colorInput.title = "Color";
+        colorInput.style.cssText = "width:28px;height:22px;padding:0;border:1px solid #638266;background:none;cursor:pointer;";
+        colorInput.onchange = () => {
+            pushHistory();
+            item.color = colorInput.value;
+            redraw();
+        };
+        propBar.append(labelText("color"), colorInput);
+
+        // Fill (rect / ellipse).
+        if (item.type === "rect" || item.type === "ellipse") {
+            const fillInput = document.createElement("input");
+            fillInput.type = "color";
+            fillInput.value = rgbToHex(item.fill || "#ffffff");
+            fillInput.title = "Fill";
+            fillInput.style.cssText = colorInput.style.cssText;
+            fillInput.onchange = () => {
+                pushHistory();
+                item.fill = fillInput.value;
+                redraw();
+            };
+            const noFill = button("no fill", () => {
+                pushHistory();
+                item.fill = "rgba(0,0,0,0)";
+                redraw();
+            }, propBar);
+            noFill.style.padding = "3px 6px";
+            propBar.append(labelText("fill"), fillInput, noFill);
+        }
+
+        // Stroke width (everything except text).
+        if (item.type !== "text") {
+            const strokeInput = document.createElement("input");
+            strokeInput.type = "number";
+            strokeInput.min = "1";
+            strokeInput.max = "60";
+            strokeInput.value = String(item.strokeWidth || 3);
+            strokeInput.style.cssText = "width:48px;font-size:11px;";
+            strokeInput.onchange = () => {
+                pushHistory();
+                item.strokeWidth = Math.max(1, Math.min(60, Math.round(Number(strokeInput.value) || 1)));
+                strokeInput.value = String(item.strokeWidth);
+                redraw();
+            };
+            propBar.append(labelText("stroke"), strokeInput);
+        }
+
+        // Font size + edit (text).
+        if (item.type === "text") {
+            const fontInput = document.createElement("input");
+            fontInput.type = "number";
+            fontInput.min = "8";
+            fontInput.max = "200";
+            fontInput.value = String(item.fontSize || 24);
+            fontInput.style.cssText = "width:54px;font-size:11px;";
+            fontInput.onchange = () => {
+                pushHistory();
+                item.fontSize = Math.max(8, Math.min(200, Math.round(Number(fontInput.value) || 8)));
+                fontInput.value = String(item.fontSize);
+                redraw();
+            };
+            const editBtn = button("Edit text", () => editText(item), propBar);
+            editBtn.style.padding = "3px 6px";
+            propBar.append(labelText("size"), fontInput, editBtn);
+        }
+
+        // z-order + duplicate (all items).
+        const front = button("Front", () => reorder(item, 1), propBar);
+        const back = button("Back", () => reorder(item, -1), propBar);
+        const dup = button("Duplicate", () => duplicate(item), propBar);
+        for (const b of [front, back, dup]) b.style.padding = "3px 6px";
+    }
+
+    function editText(item) {
+        const next = prompt("Text", item.text || "");
+        if (next === null) return;
+        pushHistory();
+        item.text = next;
+        redraw();
+    }
+
+    function reorder(item, direction) {
+        const index = board.items.indexOf(item);
+        if (index < 0) return;
+        const target = direction > 0 ? board.items.length - 1 : 0;
+        if (index === target) return;
+        pushHistory();
+        board.items.splice(index, 1);
+        if (direction > 0) {
+            board.items.push(item);
+        } else {
+            board.items.unshift(item);
+        }
+        redraw();
+    }
+
+    function duplicate(item) {
+        pushHistory();
+        const copy = structuredClone({ ...item, _node: undefined });
+        copy.id = crypto.randomUUID();
+        copy.x = (copy.x || 0) + 24;
+        copy.y = (copy.y || 0) + 24;
+        if (copy.type === "line") {
+            copy.x2 = (copy.x2 || 0) + 24;
+            copy.y2 = (copy.y2 || 0) + 24;
+        }
+        if (Array.isArray(copy.points)) {
+            copy.points = copy.points.map((p) => ({ x: p.x + 24, y: p.y + 24 }));
+        }
+        board.items.push(copy);
+        select(copy);
+    }
+
+    function deleteSelected() {
+        if (!selected) return;
+        pushHistory();
+        board.items = board.items.filter((item) => item.id !== selected.id);
+        select(null);
+    }
+
+    // ----- toolbar -----
     button("Select", () => { tool = "select"; });
     button("Pen", () => { tool = "pen"; });
     button("Text", () => {
         const text = prompt("Text", "Scene note");
-        if (text !== null) {
-            select(addItem(board, "text", { x: 44, y: 48 }));
-            selected.text = text;
-            redraw();
-        }
+        if (text === null) return;
+        pushHistory();
+        const item = addItem(board, "text", { x: 44, y: 48 });
+        item.text = text;
+        select(item);
     });
-    button("Rect", () => select(addItem(board, "rect", { x: 80, y: 90 })));
-    button("Ellipse", () => select(addItem(board, "ellipse", { x: 100, y: 110 })));
-    button("Arrow", () => select(addItem(board, "line", { x: 120, y: 140 })));
-    button("Delete", () => {
-        if (selected) {
-            board.items = board.items.filter((item) => item.id !== selected.id);
-            select(null);
-        }
-    });
+    button("Rect", () => { pushHistory(); select(addItem(board, "rect", { x: 80, y: 90 })); });
+    button("Ellipse", () => { pushHistory(); select(addItem(board, "ellipse", { x: 100, y: 110 })); });
+    button("Arrow", () => { pushHistory(); select(addItem(board, "line", { x: 120, y: 140 })); });
+    button("Delete", deleteSelected);
+    button("Undo", undo);
+    button("Redo", redo);
 
+    // ----- canvas interaction -----
     canvas.onpointerdown = (event) => {
+        canvas.focus();
         const point = pointFor(canvas, event);
+
         if (tool === "pen") {
+            pushHistory();
             penItem = { id: crypto.randomUUID(), type: "pen", points: [point], color: "#111111", strokeWidth: 4 };
             board.items.push(penItem);
             selected = penItem;
             dragging = true;
+            dragMode = "pen";
+            renderProps();
             redraw();
+            return;
+        }
+
+        // Grab a resize/endpoint handle of the already-selected item first.
+        const handle = handleAt(selected, point);
+        if (handle) {
+            pushHistory();
+            dragging = true;
+            dragMode = handle.mode;
+            dragEnd = handle.end || null;
             return;
         }
 
         const hit = hitItem(board, point);
         select(hit);
         if (hit) {
+            pushHistory();
             dragging = true;
+            dragMode = "move";
             dragOffset = { x: point.x - hit.x, y: point.y - hit.y };
         }
     };
@@ -305,9 +581,25 @@ function makeInlineBoard(node) {
             return;
         }
         const point = pointFor(canvas, event);
-        if (penItem) {
+
+        if (dragMode === "pen" && penItem) {
             penItem.points.push(point);
-        } else if (selected) {
+        } else if (dragMode === "resize" && selected) {
+            if (selected.type === "line") {
+                // handled by line-end
+            } else {
+                selected.w = Math.max(MIN_SIZE, point.x - selected.x);
+                selected.h = Math.max(MIN_SIZE, point.y - selected.y);
+            }
+        } else if (dragMode === "line-end" && selected) {
+            if (dragEnd === "start") {
+                selected.x = point.x;
+                selected.y = point.y;
+            } else {
+                selected.x2 = point.x;
+                selected.y2 = point.y;
+            }
+        } else if (dragMode === "move" && selected) {
             const oldX = selected.x;
             const oldY = selected.y;
             selected.x = point.x - dragOffset.x;
@@ -315,6 +607,10 @@ function makeInlineBoard(node) {
             if (selected.type === "line") {
                 selected.x2 += selected.x - oldX;
                 selected.y2 += selected.y - oldY;
+            } else if (Array.isArray(selected.points)) {
+                const dx = selected.x - oldX;
+                const dy = selected.y - oldY;
+                selected.points = selected.points.map((p) => ({ x: p.x + dx, y: p.y + dy }));
             }
         }
         redraw();
@@ -323,6 +619,35 @@ function makeInlineBoard(node) {
     canvas.onpointerup = () => {
         dragging = false;
         penItem = null;
+        dragMode = "move";
+        dragEnd = null;
+    };
+
+    canvas.ondblclick = (event) => {
+        const point = pointFor(canvas, event);
+        const hit = hitItem(board, point);
+        if (hit && hit.type === "text") {
+            select(hit);
+            editText(hit);
+        }
+    };
+
+    canvas.onkeydown = (event) => {
+        if (event.key === "Delete" || event.key === "Backspace") {
+            if (selected) {
+                event.preventDefault();
+                deleteSelected();
+            }
+            return;
+        }
+        const ctrlLike = event.ctrlKey || event.metaKey;
+        if (ctrlLike && event.key.toLowerCase() === "z") {
+            event.preventDefault();
+            if (event.shiftKey) redo(); else undo();
+        } else if (ctrlLike && event.key.toLowerCase() === "y") {
+            event.preventDefault();
+            redo();
+        }
     };
 
     canvas.ondragover = (event) => {
@@ -339,6 +664,7 @@ function makeInlineBoard(node) {
         }
         const point = pointFor(canvas, event);
         const src = await fileToDataUrl(file);
+        pushHistory();
         const item = {
             id: crypto.randomUUID(),
             type: "image",
@@ -354,6 +680,7 @@ function makeInlineBoard(node) {
         select(item);
     };
 
+    renderProps();
     redraw();
     return root;
 }
@@ -376,7 +703,7 @@ app.registerExtension({
             } else {
                 this.addWidget("button", "Inline board unsupported", "open", () => {}, { serialize: false });
             }
-            this.size = [680, 520];
+            this.size = [680, 560];
         };
     },
 });


### PR DESCRIPTION
코덱스 리뷰 마지막 항목 — Storyboard Board의 **P3 #8(편집 폴리시)**와 **#9(프리뷰/익스포트 일관성)**.

## #8 인라인 보드 편집 스위트
- **텍스트 사후 편집**: 텍스트 아이템 더블클릭, 또는 새 속성 바의 `Edit text` 버튼. (기존엔 생성 시 prompt 한 번뿐이라 가장 큰 갭)
- **리사이즈**: rect/ellipse/image/text는 코너 핸들, arrow/line은 양 끝점 핸들 드래그.
- **속성 바**(선택 아이템 기준): color, fill + `no fill`(rect/ellipse), stroke width, font size(text), `Front`/`Back`(z-order), `Duplicate`.
- **Undo/Redo**: 60단계 히스토리(툴바 버튼 + Ctrl/Cmd+Z, Shift+Z / +Y). 캔버스 포커스 시 Delete/Backspace로 선택 삭제.
- pen/image 이동 시 지오메트리(펜 점들)도 함께 이동.

## #9 프리뷰 = 익스포트 텍스트 래핑
- 인라인 캔버스가 이제 `storyboard_board.py`의 `_wrap_text`와 **동일 알고리즘**으로 텍스트를 박스 폭에 맞춰 단어 단위 래핑(공백 분리, 측정 폭 ≤ 박스폭 동안 같은 줄 유지, top-anchor, ~fontSize+6 줄간격, 박스 높이로 클립).
- 폰트 메트릭 차이(canvas sans-serif vs Pillow arial)로 픽셀 단위 동일은 아니지만, **익스포트가 줄바꿈하는 지점에서 프리뷰가 넘치던 문제 해소**.

## 검증
- JS 괄호 균형 OK, 핵심 함수/히스토리/단축키 배선 확인.
- 래핑은 파이썬과 동일 알고리즘(측정만 폰트 차이로 근사).
- 실제 ComfyUI 런타임 구동은 아직(로컬 node 미설치) — 캔버스 상호작용(핸들 히트·undo·드롭)은 실구동 확인 권장.

> 이로써 코덱스 non-Ideogram 리뷰 P1/P2/P3 항목 전부 대응 완료(이 PR + #5 + 레이아웃 빌더 #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
