### PR TITLE
정체성: 노드 트리를 Plan / Make / Setup 으로 접기

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-# toobusy
+# toobusy · 너무바쁜베짱이
 
-복잡한 영상 생성 워크플로우를 단순하게 만들어주는 ComfyUI 커스텀 노드 모음입니다.
+**번거로운 여러 단계를 노드 하나로 접어버리는** ComfyUI 커스텀 노드 모음입니다.
+12개 노드를 일일이 배선하기 귀찮은 사람을 위해, 한 노드가 체인 전체를 삼킵니다.
+
+> Fold tedious multi-step ComfyUI workflows into a single node.
+
+노드는 세 갈래로 접혀 있습니다:
+
+- **`toobusy/Plan`** — 기획·연출·프롬프트를 접는다: Keyframe Maker, Storyboard Board, Prompt Lines, Ideogram Layout Builder
+- **`toobusy/Make`** — 생성 파이프라인을 접는다: Z-Image Turbo, Ideogram4 T2I, LTX2.3 3종
+- **`toobusy/Setup`** — 셋업을 접는다: HF Model Auto Loader
 
 현재 공개 중점 노드:
 
@@ -37,7 +46,7 @@ git pull
 카테고리:
 
 ```text
-toobusy/Keyframe
+toobusy/Plan
 ```
 
 선택적인 참조 이미지와 짧은 아이디어를 스토리보드/키프레임 텍스트 출력으로 바꿔주는 노드입니다.
@@ -94,7 +103,7 @@ product_image + mode -> 참조 브리프
 카테고리:
 
 ```text
-toobusy/Text
+toobusy/Plan
 ```
 
 여러 줄 텍스트를 한 줄씩 프롬프트 항목으로 분리합니다. 덕분에 별도의 PromptLine 류 커스텀 노드 없이도 `toobusy Keyframe Maker.keyframe_prompts`를 바로 사용할 수 있습니다.
@@ -118,7 +127,7 @@ toobusy/Text
 카테고리:
 
 ```text
-toobusy/Storyboard
+toobusy/Plan
 ```
 
 ComfyUI 안에서 영상 아이디어, 스토리라인, 비주얼 참조, 샷 구성을 기획할 수 있는 작은 화이트보드/무드보드 노드입니다.
@@ -156,7 +165,7 @@ ComfyUI 안에서 영상 아이디어, 스토리라인, 비주얼 참조, 샷 �
 카테고리:
 
 ```text
-toobusy/Z-Image
+toobusy/Make
 ```
 
 컴팩트한 Z-Image Turbo 텍스트→이미지 워크플로우를 하나의 노드로 묶었습니다(마지막 `SaveImage` 노드는 제외).
@@ -207,7 +216,7 @@ Basic / Advanced:
 카테고리:
 
 ```text
-toobusy/LTXV
+toobusy/Make
 ```
 
 프롬프트/네거티브 인코딩과 LTX 프레임레이트 컨디셔닝을 하나의 노드로 묶었습니다.
@@ -233,7 +242,7 @@ toobusy/LTXV
 카테고리:
 
 ```text
-toobusy/LTXV
+toobusy/Make
 ```
 
 `EmptyLTXVLatentVideo`와 `LTXVEmptyLatentAudio`를 하나의 노드로 결합합니다.
@@ -269,7 +278,7 @@ LTXVAudioVAEEncode -> SolidMask(0) -> SetLatentNoiseMask
 카테고리:
 
 ```text
-toobusy/LTXV
+toobusy/Make
 ```
 
 자주 쓰는 LTX2.3 AV 샘플링 블록을 하나의 노드로 묶었습니다:

--- a/hf_model_auto_loader/model_auto_loader.py
+++ b/hf_model_auto_loader/model_auto_loader.py
@@ -71,7 +71,7 @@ class HFModelAutoLoader:
     RETURN_TYPES = ("STRING", "BOOLEAN", "STRING", "STRING")
     RETURN_NAMES = ("resolved_model_path", "found", "status", "download_url")
     FUNCTION = "scan_and_resolve"
-    CATEGORY = "toobusy/loaders"
+    CATEGORY = "toobusy/Setup"
 
     @staticmethod
     def _list_model_files(category: str) -> List[str]:

--- a/ideogram4_t2i_node/ideogram4_t2i.py
+++ b/ideogram4_t2i_node/ideogram4_t2i.py
@@ -151,7 +151,7 @@ class ToobusyIdeogram4T2I:
     RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT")
     RETURN_NAMES = ("image", "latent", "width", "height")
     FUNCTION = "generate"
-    CATEGORY = "toobusy/Ideogram4"
+    CATEGORY = "toobusy/Make"
 
     def generate(
         self,

--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -259,7 +259,7 @@ class IdeogramLayoutBuilder:
     RETURN_TYPES = ("STRING", "INT", "INT")
     RETURN_NAMES = ("ideogram_json", "width", "height")
     FUNCTION = "build"
-    CATEGORY = "toobusy/ideogram"
+    CATEGORY = "toobusy/Plan"
 
     def build(
         self,

--- a/keyframe_maker_node/keyframe_maker.py
+++ b/keyframe_maker_node/keyframe_maker.py
@@ -366,7 +366,7 @@ class ToobusyKeyframeMaker:
     RETURN_TYPES = ("STRING", "STRING", "STRING", "STRING", "STRING")
     RETURN_NAMES = ("product_brief", "shot_beats", "visual_anchor", "keyframe_prompts", "korean_story")
     FUNCTION = "make"
-    CATEGORY = "toobusy/Keyframe"
+    CATEGORY = "toobusy/Plan"
 
     def make(
         self,

--- a/ltx23_compact_sampler_node/ltx23_compact_sampler.py
+++ b/ltx23_compact_sampler_node/ltx23_compact_sampler.py
@@ -94,7 +94,7 @@ class LTX23CompactAVSampler:
     RETURN_TYPES = ("CONDITIONING", "CONDITIONING", "LATENT", "LATENT")
     RETURN_NAMES = ("positive", "negative", "video_latent", "audio_latent")
     FUNCTION = "sample"
-    CATEGORY = "toobusy/LTXV"
+    CATEGORY = "toobusy/Make"
 
     def sample(
         self,

--- a/ltx23_compact_sampler_node/ltx23_latent_prompt_nodes.py
+++ b/ltx23_compact_sampler_node/ltx23_latent_prompt_nodes.py
@@ -106,7 +106,7 @@ class LTX23EmptyAVLatents:
         "height",
     )
     FUNCTION = "create"
-    CATEGORY = "toobusy/LTXV"
+    CATEGORY = "toobusy/Make"
 
     def create(
         self,
@@ -195,7 +195,7 @@ class LTX23PromptGuide:
     RETURN_TYPES = ("CONDITIONING", "CONDITIONING", "INT", "FLOAT", "INT")
     RETURN_NAMES = ("positive", "negative", "frame_rate_int", "frame_rate_float", "length")
     FUNCTION = "encode"
-    CATEGORY = "toobusy/LTXV"
+    CATEGORY = "toobusy/Make"
 
     def encode(
         self,

--- a/prompt_lines_node/prompt_lines.py
+++ b/prompt_lines_node/prompt_lines.py
@@ -15,7 +15,7 @@ class ToobusyPromptLines:
     RETURN_NAMES = ("line", "text", "count")
     OUTPUT_IS_LIST = (True, False, False)
     FUNCTION = "split"
-    CATEGORY = "toobusy/Text"
+    CATEGORY = "toobusy/Plan"
 
     def split(self, source, start_index, max_rows, remove_empty_lines, strip_lines):
         lines = str(source or "").splitlines()

--- a/storyboard_board_node/storyboard_board.py
+++ b/storyboard_board_node/storyboard_board.py
@@ -149,7 +149,7 @@ class ToobusyStoryboardBoard:
     RETURN_TYPES = ("IMAGE", "STRING")
     RETURN_NAMES = ("image", "board_data")
     FUNCTION = "render"
-    CATEGORY = "toobusy/Storyboard"
+    CATEGORY = "toobusy/Plan"
 
     def render(self, board_data, width, height, background):
         width = int(width)

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -153,7 +153,7 @@ class ToobusyZImageTurbo:
     RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT")
     RETURN_NAMES = ("image", "latent", "width", "height")
     FUNCTION = "generate"
-    CATEGORY = "toobusy/Z-Image"
+    CATEGORY = "toobusy/Make"
 
     def generate(
         self,


### PR DESCRIPTION
파편화된 7개 카테고리(Keyframe·Text·Storyboard·Z-Image·LTXV·ideogram·loaders·Ideogram4)를 3버킷으로 접어 정체성을 코드로 박음 — '번거로운 멀티스텝을 노드 하나로 접는다'.

- toobusy/Plan: Keyframe Maker, Storyboard Board, Prompt Lines, Ideogram Layout Builder
- toobusy/Make: Z-Image Turbo, Ideogram4 T2I, LTX2.3 3종
- toobusy/Setup: HF Model Auto Loader

README 히어로를 접기 정체성(너무바쁜베짱이 브랜드)로 재작성 + 영문 1줄 + 카테고리 표기 동기화. 전 노드 compileall 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)