### PR TITLE
패키징: Registry 등록 가능 상태로 (LICENSE/pyproject/CI/.comfyignore)

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -1,0 +1,19 @@
+# Files excluded from the published ComfyUI Registry package.
+.git/
+.github/
+.gitignore
+.comfyignore
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.DS_Store
+Thumbs.db
+
+# Dev/large media should never be shipped in the node package.
+*.blend
+*.blend1
+*.wav
+*.mp4
+*.mov
+*.psd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  python-compile:
+    name: Python compile (node registration / syntax)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Byte-compile all node packages
+        run: |
+          python -m compileall -q \
+            __init__.py \
+            hf_model_auto_loader \
+            ideogram4_t2i_node \
+            ideogram_layout_builder \
+            keyframe_maker_node \
+            ltx23_compact_sampler_node \
+            prompt_lines_node \
+            storyboard_board_node \
+            z_image_turbo_node
+
+  js-syntax:
+    name: Frontend JS syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Parse every frontend module (ESM syntax check)
+        run: npx --yes esbuild js/*.js --outdir=/tmp/esbuild-check --format=esm --log-level=warning

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to Comfy Registry
+
+# Publishes to the ComfyUI Registry when a version tag (e.g. v0.1.0) is pushed.
+# Requires:
+#   1. A registry.comfy.org publisher whose id matches [tool.comfy].PublisherId
+#      in pyproject.toml (currently "nicekriss" — placeholder, update when real).
+#   2. A repo secret REGISTRY_ACCESS_TOKEN with that publisher's API key.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish node
+        uses: Comfy-Org/publish-node-action@main
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
+
+## [0.1.0] - 2026-06-07
+
+첫 패키징 릴리스. 정체성을 **"번거로운 멀티스텝을 노드 하나로 접는다"**로 정하고,
+노드 메뉴를 `toobusy/Plan` · `toobusy/Make` · `toobusy/Setup` 세 갈래로 정리.
+
+### Added
+- 패키징: `pyproject.toml`(Registry), `LICENSE`(MIT), `.comfyignore`, `CHANGELOG`, GitHub Actions CI(Python compile + JS 문법 체크).
+- Ideogram Layout Builder: 요소 역할(role) 힌트, 레이아웃 템플릿, `strict_text`/`reinforce_text`/`include_global_palette` 토글, 레이어 리스트, 키보드 단축키.
+- Storyboard Board: 텍스트 사후 편집, 리사이즈 핸들, 속성 바(색/채움/선/폰트/z-order/복제), Undo/Redo, 프리뷰 텍스트 래핑(익스포트와 일치).
+- Z-Image Turbo: Basic/Advanced 토글, 해상도 미리보기 readout.
+- LTX2.3 Empty AV Latents: 해상도/길이/오디오 readout + 커스텀 오디오 미연결 경고.
+- LTX2.3 Compact AV Sampler: `manual_sigmas` Advanced 숨김 + SIGMAS 연결 시 오버라이드 표시.
+- Keyframe Maker: 생성 결과를 override로 복사하는 버튼.
+
+### Changed
+- 카테고리 7개 파편 → 3버킷(Plan/Make/Setup)으로 통합.
+- HF Model Auto Loader: `download_if_missing` 기본값 `True` → `False`(스캔/리포트 우선), `Open on Hugging Face` 버튼으로 정정.
+- Ideogram4 T2I 표시명을 "(local model)"로 명확화 — 웹 API가 아니라 로컬 모델 샘플러임.
+- 모델 경로 기본값의 백슬래시를 포워드슬래시로 변경(크로스플랫폼).
+- README 전면 한글화 + 접기 정체성 반영.
+
+### Fixed
+- Layout Builder: 최소 크기(40px) 박스가 백엔드에서 조용히 삭제되던 문제, 깨진 `elements_json`이 그래프 전체를 중단시키던 문제, 해상도 입력이 타이핑 중 클램프되던 문제.
+- HF Model Auto Loader: 존재하지 않는 위젯을 참조해 동작하지 않던 다운로드 버튼.
+- 죽은 중복 JS 파일 및 미사용 `WEB_DIRECTORY` 정리.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 너무바쁜베짱이 (toobusy)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ideogram4_t2i_node/ideogram4_t2i.py
+++ b/ideogram4_t2i_node/ideogram4_t2i.py
@@ -88,6 +88,14 @@ def _resolution(ratio_preset, megapixels):
 
 
 class ToobusyIdeogram4T2I:
+    """Folded text-to-image sampler for a LOCAL Ideogram 4 model in ComfyUI.
+
+    This is NOT the Ideogram web API. It runs a local Ideogram 4 checkpoint
+    (CLIP type `ideogram4`, `Ideogram4Scheduler`) through the whole
+    load -> encode -> sample -> decode chain as a single node, and accepts the
+    Layout Builder's structured-prompt JSON as its prompt.
+    """
+
     @classmethod
     def INPUT_TYPES(cls):
         diffusion_names = _diffusion_model_names()
@@ -250,7 +258,7 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "ToobusyIdeogram4T2I": "toobusy Ideogram4 T2I",
+    "ToobusyIdeogram4T2I": "toobusy Ideogram4 T2I (local model)",
 }
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "toobusy"
+description = "Fold tedious multi-step ComfyUI workflows into a single node — pre-production, storyboard, keyframe, and structured-prompt nodes for video generation."
+version = "0.1.0"
+license = { file = "LICENSE" }
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "너무바쁜베짱이 (toobusy)" }]
+keywords = [
+    "comfyui",
+    "comfyui-nodes",
+    "comfyui-custom-nodes",
+    "workflow",
+    "fold",
+    "pre-production",
+    "storyboard",
+    "keyframe",
+    "shot-planning",
+    "prompt",
+    "ideogram",
+    "layout",
+    "ltx",
+    "ltx-video",
+    "z-image",
+    "video",
+    "direction",
+]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+# huggingface_hub is only needed by the HF Model Auto Loader's download path and
+# is handled gracefully when absent, but it ships with most ComfyUI installs;
+# list it so that path works out of the box.
+dependencies = [
+    "huggingface_hub",
+]
+
+[project.urls]
+Repository = "https://github.com/nicekriss/toobusy"
+"Bug Tracker" = "https://github.com/nicekriss/toobusy/issues"
+
+[tool.comfy]
+PublisherId = "nicekriss"
+DisplayName = "toobusy · 너무바쁜베짱이"
+Repository = "https://github.com/nicekriss/toobusy"

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -39,26 +39,26 @@ def _model_names():
     names = _folder_list("diffusion_models", [])
     if not names:
         names = _folder_list("unet", [])
-    return names or ["ZIT\\zImage_turbo.safetensors"]
+    return names or ["ZIT/zImage_turbo.safetensors"]
 
 
 def _clip_names():
     names = _folder_list("text_encoders", [])
     if not names:
         names = _folder_list("clip", [])
-    return names or ["ZIT\\zImage_textEncoder.safetensors"]
+    return names or ["ZIT/zImage_textEncoder.safetensors"]
 
 
 def _vae_names():
-    return _folder_list("vae", ["FLUX1\\ae.safetensors"])
+    return _folder_list("vae", ["FLUX1/ae.safetensors"])
 
 
 def _lora_names():
-    return ["None"] + _folder_list("loras", ["Lora\\ZIT\\ZIT_Neobabae_v1.safetensors"])
+    return ["None"] + _folder_list("loras", ["Lora/ZIT/ZIT_Neobabae_v1.safetensors"])
 
 
 def _default_lora_name(lora_names):
-    preferred = ["Lora\\ZIT\\ZIT_Neobabae_v1.safetensors", "ZIT\\ZIT_Neobabae_v1.safetensors"]
+    preferred = ["Lora/ZIT/ZIT_Neobabae_v1.safetensors", "ZIT/ZIT_Neobabae_v1.safetensors"]
     for name in preferred:
         if name in lora_names:
             return name
@@ -108,9 +108,9 @@ class ToobusyZImageTurbo:
 
         base = {
             "required": {
-                "model_name": (model_names, {"default": _first_existing(model_names, ["ZIT\\zImage_turbo.safetensors"])}),
-                "clip_name": (clip_names, {"default": _first_existing(clip_names, ["ZIT\\zImage_textEncoder.safetensors"])}),
-                "vae_name": (vae_names, {"default": _first_existing(vae_names, ["FLUX1\\ae.safetensors"])}),
+                "model_name": (model_names, {"default": _first_existing(model_names, ["ZIT/zImage_turbo.safetensors"])}),
+                "clip_name": (clip_names, {"default": _first_existing(clip_names, ["ZIT/zImage_textEncoder.safetensors"])}),
+                "vae_name": (vae_names, {"default": _first_existing(vae_names, ["FLUX1/ae.safetensors"])}),
                 "positive": ("STRING", {"default": "", "multiline": True}),
                 "negative": ("STRING", {"default": "", "multiline": True}),
                 "ratio_preset": (list(RATIO_PRESETS.keys()), {"default": "2:3"}),


### PR DESCRIPTION
제품/배포 인프라 전무 상태를 해소 — ComfyUI Registry 등록 + Manager 노출의 전제.

- LICENSE (MIT, 저작자 너무바쁜베짱이)
- pyproject.toml ([project] + 접기/프리프로덕션 키워드 + [tool.comfy] PublisherId=nicekriss placeholder)
- .comfyignore (.blend/.wav/대용량/캐시 제외)
- CHANGELOG.md (0.1.0)
- GitHub Actions CI: Python compileall + esbuild ESM 문법 체크 / publish.yml(태그 시 Registry 발행)
- 크로스플랫폼: 모델 경로 기본값 백슬래시 → 포워드슬래시
- 네이밍: Ideogram4 T2I 표시명 '(local model)' + 로컬 모델임을 docstring 명시

검증: TOML 파싱 OK, 전 노드 compileall 0, 백슬래시 경로 0.
남은 §7: 예제 워크플로우 .json은 ComfyUI에서 export하는 게 안전해 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)