### PR TITLE
README: Before -> After 섹션 + 예제 워크플로우 자리

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@
 
 이 외에도 몇 개의 추가/실험적 노드(Ideogram Layout Builder, Ideogram4 T2I 포함)가 함께 등록되어 있습니다 — [추가 / 실험적 노드](#추가--실험적-노드) 참고.
 
+## 왜 "접기"인가 — Before → After
+
+설치하면 **기존 그래프가 짧아집니다.** 그게 toobusy의 약속입니다.
+
+| 노드 | Before (직접 배선) | After |
+|---|---|---|
+| **Z-Image Turbo** | UNET·CLIP·VAE 로더 + (LoRA×N) + ModelSamplingAuraFlow + CLIPTextEncode×2 + EmptyLatentImage + KSampler + VAEDecode — 약 10노드 | **1 노드** |
+| **Ideogram4 T2I** | 로더 4 + 인코딩 + ConditioningZeroOut + CFGOverride + DualModelGuider + RandomNoise + KSamplerSelect + Ideogram4Scheduler + EmptyLatent + SamplerCustomAdvanced + VAEDecode — 약 13노드 | **1 노드** |
+| **LTX2.3 Compact AV Sampler** | RandomNoise + ConcatAVLatent + CFGGuider + KSamplerSelect + ManualSigmas + SamplerCustomAdvanced + SeparateAVLatent + CropGuides — 8노드 | **1 노드** |
+| **LTX2.3 Empty AV Latents** | EmptyLTXVLatentVideo + LTXVEmptyLatentAudio (+커스텀 오디오: AudioVAEEncode + SolidMask + SetLatentNoiseMask) | **1 노드** |
+| **Keyframe Maker** | 브리프 → 샷 비트 → 비주얼 앵커 → 키프레임 → 스토리, 5단계 수동 프롬프팅 | **1 노드** |
+| **Storyboard Board** | 외부 화이트보드 앱 + 캡처 + 임포트 | **노드 안에서 바로** |
+| **Ideogram Layout Builder** | 구조화 프롬프트 JSON을 손으로 작성 | **캔버스에 박스 드래그** |
+
+> 새 노드 추가 기준도 동일합니다: **"이게 귀찮은 여러 단계를 하나로 접나?"** — Yes만 들어옵니다.
+
 ## 설치
 
 이 저장소를 `ComfyUI/custom_nodes` 아래에 `toobusy`라는 이름으로 클론한 뒤 ComfyUI를 재시작하세요.

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,0 +1,19 @@
+# 예제 워크플로우
+
+각 노드가 **무엇을 접는지** 한눈에 보여주는 검증된 워크플로우를 여기에 둡니다.
+(kijai 정찰에서 배운 점: "노드가 있다"보다 "이 워크플로우 열면 돌아간다"가 신뢰를 만든다.)
+
+## 넣는 방법
+
+1. ComfyUI에서 노드를 실제로 배선해 동작을 확인합니다.
+2. 메뉴 → **Workflow → Export (.json)** 로 내보냅니다.
+3. 이 폴더에 `노드이름.json` 으로 저장합니다 (예: `z_image_turbo.json`).
+4. 루트 README에서 해당 노드 섹션에 링크합니다.
+
+## 권장 목록 (before → after를 가장 잘 보여주는 순서)
+
+- [ ] `z_image_turbo.json` — t2i 그래프 ~10노드 → 1노드
+- [ ] `ltx_compact_av_sampler.json` — 샘플링 블록 8노드 → 1노드
+- [ ] `keyframe_maker.json` — 5단계 기획 → 1노드 (텍스트 생성 CLIP 연결 포함)
+- [ ] `storyboard_board.json` — 인라인 보드 → IMAGE export
+- [ ] `ideogram_layout_to_t2i.json` — Layout Builder → Ideogram4 T2I 연결


### PR DESCRIPTION
Coda의 kijai 정찰이 한 점으로 모은 '10초 안에 전후가 보이는가'에 대응. 각 노드가 몇 노드를 대체하는지 Before -> After 표 + 신규 노드 게이트('체인을 접나?'). docs/workflows/ 스캐폴드(검증된 워크플로우 export 자리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)