### PR TITLE
투명성 장치 + Registry 태그라인 (Coda flagship 반영)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **번거로운 여러 단계를 노드 하나로 접어버리는** ComfyUI 커스텀 노드 모음입니다.
 12개 노드를 일일이 배선하기 귀찮은 사람을 위해, 한 노드가 체인 전체를 삼킵니다.
 
-> Fold tedious multi-step ComfyUI workflows into a single node.
+> **Fold the graph.** — toobusy folds tedious multi-step ComfyUI workflows into single production nodes.
 
 노드는 세 갈래로 접혀 있습니다:
 

--- a/js/toobusy_z_image_turbo.js
+++ b/js/toobusy_z_image_turbo.js
@@ -152,6 +152,16 @@ app.registerExtension({
         nodeType.prototype.onNodeCreated = function () {
             onNodeCreated?.apply(this, arguments);
 
+            // Transparency: show what this one node folds, so intermediate users
+            // can see inside the "black box" instead of distrusting it.
+            this.addWidget(
+                "text",
+                "folds",
+                "Folds ~10 nodes: UNET+CLIP+VAE +(LoRA) → AuraFlow → Encode×2 → EmptyLatent → KSampler → Decode",
+                () => {},
+                { serialize: false },
+            );
+
             // Always-visible resolution readout (sits right after the inputs,
             // above the LoRA/advanced buttons).
             this.addWidget("text", "resolution_readout", "", () => {}, { serialize: false });

--- a/ltx23_compact_sampler_node/ltx23_compact_sampler.py
+++ b/ltx23_compact_sampler_node/ltx23_compact_sampler.py
@@ -57,6 +57,13 @@ def _default_sampler_name(sampler_names):
 
 
 class LTX23CompactAVSampler:
+    """Folds the LTX 2.3 audio+video sampling block into one node.
+
+    Replaces: RandomNoise + LTXVConcatAVLatent + CFGGuider + KSamplerSelect +
+    ManualSigmas + SamplerCustomAdvanced + LTXVSeparateAVLatent + LTXVCropGuides
+    (8 nodes -> 1). Requires the LTX 2.3 (LTXV*) node set installed.
+    """
+
     @classmethod
     def INPUT_TYPES(cls):
         sampler_names = _sampler_names()

--- a/ltx23_compact_sampler_node/ltx23_latent_prompt_nodes.py
+++ b/ltx23_compact_sampler_node/ltx23_latent_prompt_nodes.py
@@ -77,6 +77,13 @@ def _ltx_length(duration_seconds, frame_rate):
 
 
 class LTX23EmptyAVLatents:
+    """Folds LTX 2.3 empty audio+video latent setup into one node.
+
+    Replaces EmptyLTXVLatentVideo + LTXVEmptyLatentAudio (and, for custom audio,
+    LTXVAudioVAEEncode + SolidMask + SetLatentNoiseMask). Requires the LTX 2.3
+    (LTXV*) node set installed.
+    """
+
     @classmethod
     def INPUT_TYPES(cls):
         return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toobusy"
-description = "Fold tedious multi-step ComfyUI workflows into a single node — pre-production, storyboard, keyframe, and structured-prompt nodes for video generation."
+description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
 version = "0.1.0"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -97,6 +97,14 @@ def _resolution_from_megapixels(ratio_preset, megapixels, divisible_by):
 
 
 class ToobusyZImageTurbo:
+    """Folds a full Z-Image Turbo text-to-image graph into one node.
+
+    Replaces, in order: UNETLoader + CLIPLoader + VAELoader + (optional
+    LoraLoader chain) + ModelSamplingAuraFlow + CLIPTextEncode x2 +
+    EmptyLatentImage + KSampler + VAEDecode (~10 nodes -> 1).
+    Needs Z-Image Turbo model + lumina2 text encoder + VAE in your model folders.
+    """
+
     @classmethod
     def INPUT_TYPES(cls):
         model_names = _model_names()


### PR DESCRIPTION
Coda의 kijai 정찰 답을 코드에 반영.

- Registry description = Coda의 첫 문장, README 히어로에 'Fold the graph.' 태그라인.
- risk #5(접기가 강할수록 중급자 불신) 대응 = 노드 docstring(ComfyUI 노드 help)에 '이 노드가 무엇을 대체하는지' 명시(Z-Image/LTX Compact/LTX Empty AV).
- flagship Z-Image는 노드 본체에 'Folds ~10 nodes: ...' 라인 가시 표시.

검증: compileall 0, JS 균형 OK, TOML 유효.

🤖 Generated with [Claude Code](https://claude.com/claude-code)