### PR TITLE
Plan 파이프라인 연결 + 뉘앙스 보존 (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [0.2.1] - 2026-06-07
+
+### Added
+- **Plan 파이프라인 연결**: Ideogram Layout Builder가 이제 Prompt Polish의 전체
+  Ideogram payload(`compositional_deconstruction.elements`)를 입력으로 받아들이고,
+  bbox를 Ideogram 순서 `[y,x,y,x]` → 캔버스 순서 `[x,y,x,y]`로 올바르게 변환합니다.
+  덕분에 `Prompt Polish → Layout Builder → Ideogram4 T2I`가 좌표까지 정확히 연결됩니다
+  (한국어 장면 → 구조화 레이아웃 → 이미지). 기존 입력 형식(배열, `{elements}`)은 그대로 동작.
+
+### Changed
+- Prompt Polish: `preserve_intent`가 켜졌을 때 한국어의 정서·분위기·관계성 뉘앙스를
+  보존하고 서구식 stock 프롬프트로 평탄화하지 않도록 지시를 강화.
+
 ## [0.2.0] - 2026-06-07
 
 ### Added

--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -133,6 +133,19 @@ def _element_type(text, desc):
     return "text" if text else "obj"
 
 
+def _from_ideogram_element(element):
+    # A full Ideogram payload (e.g. from Prompt Polish) stores bbox in Ideogram
+    # order [y_min, x_min, y_max, x_max]; the builder works in canvas order
+    # [x_min, y_min, x_max, y_max], so swap it back when ingesting one.
+    if not isinstance(element, dict):
+        return element
+    bbox = element.get("bbox")
+    if isinstance(bbox, list) and len(bbox) == 4:
+        y_min, x_min, y_max, x_max = bbox
+        return {**element, "bbox": [x_min, y_min, x_max, y_max]}
+    return element
+
+
 def _load_elements(elements_json):
     if not elements_json.strip():
         return []
@@ -144,12 +157,19 @@ def _load_elements(elements_json):
         # default centered subject.
         print("[toobusy ideogram] elements_json is not valid JSON; ignoring it.")
         return []
+    if isinstance(data, list):
+        return data
     if isinstance(data, dict):
-        data = data.get("elements", [])
-    if not isinstance(data, list):
-        print("[toobusy ideogram] elements_json must be a JSON array or an object with an 'elements' array; ignoring it.")
-        return []
-    return data
+        # Plain {"elements": [...]} (already canvas-order bbox).
+        if isinstance(data.get("elements"), list):
+            return data["elements"]
+        # Full Ideogram payload (e.g. piped from Prompt Polish): pull the elements
+        # out of compositional_deconstruction and convert bbox order back.
+        comp = data.get("compositional_deconstruction")
+        if isinstance(comp, dict) and isinstance(comp.get("elements"), list):
+            return [_from_ideogram_element(item) for item in comp["elements"]]
+    print("[toobusy ideogram] elements_json must be a JSON array, an object with an 'elements' array, or a full Ideogram payload; ignoring it.")
+    return []
 
 
 class IdeogramLayoutBuilder:

--- a/ideogram_prompt_polish_node/prompt_polish.py
+++ b/ideogram_prompt_polish_node/prompt_polish.py
@@ -110,7 +110,11 @@ def _build_prompt(scene, style_mode, language, preserve_intent, fill_missing, ex
     else:
         lines.append(f"The scene is written in {language}; output English.")
     if preserve_intent:
-        lines.append("Stay faithful to the user's intent. Do not introduce a different subject; only add detail needed for clarity.")
+        lines.append(
+            "Stay faithful to the user's intent. Do not introduce a different subject; only add detail needed for clarity. "
+            "Preserve the original mood, emotional tone, and relationships — especially subtle nuance in Korean input. "
+            "Translate the user's meaning so Ideogram understands it; do NOT flatten it into generic Western stock-photo phrasing."
+        )
     if fill_missing:
         lines.append("Fill any missing fields with sensible defaults consistent with the scene.")
 

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -154,8 +154,22 @@ function clamp(value, min = 0, max = CANVAS_SIZE) {
 function parseElements(value) {
     try {
         const parsed = JSON.parse(value || "[]");
-        const elements = Array.isArray(parsed) ? parsed : parsed.elements;
-        return Array.isArray(elements) ? elements : [];
+        if (Array.isArray(parsed)) return parsed;
+        if (parsed && Array.isArray(parsed.elements)) return parsed.elements;
+        // Full Ideogram payload (e.g. piped from Prompt Polish): pull elements
+        // out of compositional_deconstruction and swap bbox from Ideogram order
+        // [y,x,y,x] back to canvas order [x,y,x,y].
+        const comp = parsed && parsed.compositional_deconstruction;
+        if (comp && Array.isArray(comp.elements)) {
+            return comp.elements.map((el) => {
+                if (el && Array.isArray(el.bbox) && el.bbox.length === 4) {
+                    const [y1, x1, y2, x2] = el.bbox;
+                    return { ...el, bbox: [x1, y1, x2, y2] };
+                }
+                return el;
+            });
+        }
+        return [];
     } catch {
         return [];
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.2.0"
+version = "0.2.1"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Coda 답장 반영. Prompt Polish → Layout Builder → Ideogram4 파이프라인이 좌표까지 올바르게 연결되도록.

- Layout Builder가 full Ideogram payload(compositional_deconstruction.elements) 인제스트 + bbox 순서 [y,x,y,x]→[x,y,x,y] 변환. 기존 형식도 유지.
- round-trip 검증: payload in → 동일 ideogram bbox out, plain array/elements도 동작.
- Prompt Polish preserve_intent 강화(한국어 뉘앙스 평탄화 방지, Coda risk #5).
- 스키마 순수성(boost #1)은 이미 충족 — status는 llm_raw로만.

검증: compileall 0, JS 균형 OK, 라운드트립 테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)