### PR TITLE
Layout Builder: Import polished 모달 (v0.2.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 .vscode/
 .idea/
 
-# Private local mailbox for Crux <-> Coda notes (never published).
+# Private local Crux <-> Coda collaboration notes (never published).
 AGENT_MAILBOX.md
+CODA_HANDOFF.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [0.2.3] - 2026-06-07
+
+### Changed
+- Layout Builder의 **`Import polished`** 흐름을 한 줄 `window.prompt()`에서 큰
+  붙여넣기 모달로 개선했습니다. Prompt Polish / Ideogram JSON을 넉넉한 textarea에
+  붙여넣고, JSON 파싱 오류와 payload 형식 오류를 인라인으로 확인한 뒤, 유효할 때만
+  scene·요소 수 미리보기를 보고 `Apply`할 수 있습니다. `Apply` 전에는 현재 캔버스와
+  scene/style/background/palette 필드를 교체하지 않습니다.
+
 ## [0.2.2] - 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -359,7 +359,10 @@ RandomNoise -> LTXVConcatAVLatent -> CFGGuider -> KSamplerSelect -> ManualSigmas
   반복 — 끄면 컴팩트 JSON), `include_global_palette`(전역 팔레트를 생략해 색을
   열어둠). 편집 보조로 **레이어 리스트**(가려진 박스도 클릭해 선택 + 앞/뒤 순서
   변경 + 삭제)와 **키보드 단축키**(캔버스 포커스 상태에서 Delete/Backspace 삭제,
-  방향키 이동 · Shift로 크게 이동, Esc 선택 해제)를 제공합니다.
+  방향키 이동 · Shift로 크게 이동, Esc 선택 해제)를 제공합니다. **Import polished**는
+  Prompt Polish의 `ideogram_json`을 큰 붙여넣기 모달에서 JSON 파싱/형식 검증과
+  scene·요소 수 미리보기까지 확인한 뒤, `Apply`를 눌렀을 때만 현재 캔버스와
+  scene/style/background/palette 필드를 교체합니다.
 - `ideogram4_t2i_node` (`toobusy Ideogram4 T2I`) — 프롬프트로부터 로컬 Ideogram 4
   모델(CLIP `ideogram4`, `Ideogram4Scheduler`)을 실행합니다. Layout Builder의 JSON
   프롬프트와 `width`/`height`를 그대로 받습니다.

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -610,6 +610,76 @@ function installEditor(node) {
                 cursor: pointer;
             }
             .toobusy-ideogram button:hover { background: #303844; }
+            .toobusy-ideogram button:disabled {
+                opacity: 0.45;
+                cursor: default;
+            }
+            .toobusy-ideogram button:disabled:hover { background: #252b33; }
+            .toobusy-ideogram .import-modal-backdrop {
+                position: fixed;
+                inset: 0;
+                z-index: 9999;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 24px;
+                background: rgba(3, 6, 10, 0.66);
+            }
+            .toobusy-ideogram .import-modal-backdrop[hidden] { display: none; }
+            .toobusy-ideogram .import-modal {
+                width: min(720px, 92vw);
+                max-height: 86vh;
+                overflow: auto;
+                border: 1px solid #596574;
+                border-radius: 8px;
+                background: #11171f;
+                box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+                padding: 14px;
+                user-select: text;
+            }
+            .toobusy-ideogram .import-modal-head,
+            .toobusy-ideogram .import-modal-actions {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 10px;
+            }
+            .toobusy-ideogram .import-modal-title {
+                font-size: 13px;
+                font-weight: 700;
+                color: #edf2f7;
+            }
+            .toobusy-ideogram .import-modal-subtitle {
+                margin: 4px 0 10px;
+                color: #9fb0c0;
+                font-size: 11px;
+            }
+            .toobusy-ideogram .import-modal textarea {
+                min-height: 260px;
+                resize: vertical;
+                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+                font-size: 11px;
+                line-height: 1.45;
+            }
+            .toobusy-ideogram .import-modal-status {
+                min-height: 52px;
+                margin: 10px 0;
+                padding: 9px;
+                border: 1px solid #35404b;
+                border-radius: 6px;
+                background: #0d1218;
+                color: #cbd5df;
+                white-space: pre-wrap;
+                overflow-wrap: anywhere;
+            }
+            .toobusy-ideogram .import-modal-status.error {
+                border-color: #7d3d44;
+                color: #ffb8c1;
+                background: #1a1013;
+            }
+            .toobusy-ideogram .import-modal-actions {
+                justify-content: flex-end;
+            }
             .toobusy-ideogram .element {
                 display: flex;
                 flex-direction: column;
@@ -1388,28 +1458,117 @@ function installEditor(node) {
         };
     }
 
+    let importDialog = null;
+    function openImportPolishedDialog() {
+        if (!importDialog) {
+            const backdrop = document.createElement("div");
+            backdrop.className = "import-modal-backdrop";
+            backdrop.hidden = true;
+
+            const modal = document.createElement("div");
+            modal.className = "import-modal";
+            modal.addEventListener("pointerdown", (event) => event.stopPropagation());
+            modal.addEventListener("pointerup", (event) => event.stopPropagation());
+
+            const head = document.createElement("div");
+            head.className = "import-modal-head";
+            const title = document.createElement("div");
+            title.className = "import-modal-title";
+            title.textContent = "Import polished";
+            const closeButton = makeButton("Close", "Close without changing the layout", () => close());
+            head.append(title, closeButton);
+
+            const subtitle = document.createElement("div");
+            subtitle.className = "import-modal-subtitle";
+            subtitle.textContent = "Paste Prompt Polish ideogram_json. Nothing changes until Apply.";
+
+            const textarea = document.createElement("textarea");
+            textarea.spellcheck = false;
+            textarea.placeholder = "{\n  \"high_level_description\": \"...\",\n  \"compositional_deconstruction\": { \"elements\": [...] }\n}";
+
+            const status = document.createElement("div");
+            status.className = "import-modal-status";
+
+            const actions = document.createElement("div");
+            actions.className = "import-modal-actions";
+            const cancelButton = makeButton("Cancel", "Close without changing the layout", () => close());
+            const applyButton = makeButton("Apply", "Replace the current layout with this parsed payload", () => {
+                if (!importDialog.state) return;
+                applyState(importDialog.state);
+                close();
+            });
+            applyButton.disabled = true;
+            actions.append(cancelButton, applyButton);
+
+            modal.append(head, subtitle, textarea, status, actions);
+            backdrop.appendChild(modal);
+            root.appendChild(backdrop);
+
+            const setStatus = (message, isError = false) => {
+                status.textContent = message;
+                status.classList.toggle("error", isError);
+            };
+            const validate = () => {
+                const raw = textarea.value.trim();
+                importDialog.state = null;
+                applyButton.disabled = true;
+                if (!raw) {
+                    setStatus("Paste ideogram_json to preview the scene and element count.", false);
+                    return;
+                }
+                let parsed;
+                try {
+                    parsed = JSON.parse(raw);
+                } catch (err) {
+                    setStatus(`JSON parse error: ${err.message}`, true);
+                    return;
+                }
+                const state = payloadToState(parsed);
+                if (!state) {
+                    setStatus("Ideogram payload shape not recognized. Expected high_level_description and/or compositional_deconstruction.elements.", true);
+                    return;
+                }
+                importDialog.state = state;
+                applyButton.disabled = false;
+                const scenePreview = state.high_level_description || "(no scene)";
+                const fields = [
+                    `Elements: ${state.elements.length}`,
+                    `Scene: ${scenePreview}`,
+                    state.background ? `Background: ${state.background}` : "",
+                    state.global_palette ? `Palette: ${state.global_palette}` : "",
+                ].filter(Boolean);
+                setStatus(`${fields.join("\n")}\n\nApply will replace the current canvas boxes and scene/style fields.`, false);
+            };
+            textarea.addEventListener("input", validate);
+
+            const close = () => {
+                backdrop.hidden = true;
+                importDialog.state = null;
+            };
+            const open = () => {
+                textarea.value = "";
+                validate();
+                backdrop.hidden = false;
+                setTimeout(() => textarea.focus(), 0);
+            };
+            backdrop.addEventListener("pointerdown", (event) => {
+                if (event.target === backdrop) close();
+            });
+            root.addEventListener("keydown", (event) => {
+                if (!backdrop.hidden && event.key === "Escape") {
+                    event.preventDefault();
+                    close();
+                }
+            });
+            importDialog = { open, state: null };
+        }
+        importDialog.open();
+    }
+
     presetBar.append(
         presetBarTitle,
         presetSelectEl,
-        makeButton("Import polished", "Paste a Prompt Polish / Ideogram JSON to load it (preview before it replaces the layout)", () => {
-            const raw = window.prompt("Paste the Prompt Polish output (ideogram_json):", "");
-            if (!raw || !raw.trim()) return;
-            let parsed;
-            try {
-                parsed = JSON.parse(raw);
-            } catch {
-                window.alert("유효한 JSON이 아닙니다.");
-                return;
-            }
-            const state = payloadToState(parsed);
-            if (!state) {
-                window.alert("Ideogram payload 형식이 아닙니다 (high_level_description / compositional_deconstruction 필요).");
-                return;
-            }
-            const scenePreview = (state.high_level_description || "(없음)").slice(0, 50);
-            const ok = window.confirm(`요소 ${state.elements.length}개 · scene: "${scenePreview}"\n\n현재 레이아웃을 이걸로 교체할까요? (지금 값은 교체 전까지 보존됩니다)`);
-            if (ok) applyState(state);
-        }),
+        makeButton("Import polished", "Paste a Prompt Polish / Ideogram JSON to load it (preview before it replaces the layout)", openImportPolishedDialog),
         makeButton("Save", "Save current layout as a named preset", () => {
             const name = (window.prompt("Preset name:") || "").trim();
             if (!name) return;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.2.2"
+version = "0.2.3"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
로컬 Coda(Codex) 구현, Crux 검수 후 채택.

window.prompt → 제대로 된 붙여넣기 모달: 큰 textarea, 타이핑마다 JSON/payload 인라인 검증, 유효할 때만 Apply 활성화, scene·요소수 미리보기, Apply 전 원본 보존, Esc/바깥클릭/Cancel로 닫기. v0.2.2의 payloadToState/applyState 재사용(정합성 유지).

검증: node --check + compileall. CODA_HANDOFF.md는 로컬(gitignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)