### PR TITLE
Guard disabled palette controls

### DIFF
--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -239,6 +239,7 @@ function makeButton(text, title, onClick) {
         event.stopPropagation();
         if (!armed) return;
         armed = false;
+        if (button.disabled) return;
         try {
             onClick();
         } catch (err) {
@@ -384,6 +385,7 @@ function makePaletteEditor(labelText, colors, onInput, count = 5, options = {}) 
     }
 
     function addSwatch(color) {
+        if (dynamic && swatches.length >= maxCount) return false;
         const wrap = document.createElement("div");
         wrap.className = "color-swatch-wrap";
         const swatch = document.createElement("input");
@@ -414,12 +416,14 @@ function makePaletteEditor(labelText, colors, onInput, count = 5, options = {}) 
         }
         row.appendChild(wrap);
         updateControls();
+        return true;
     }
 
     const addColor = dynamic
         ? makeButton("+", "Add an element color", () => {
-            addSwatch(swatches[swatches.length - 1]?.dataset.color || "#FFFFFF");
-            emit();
+            if (addSwatch(swatches[swatches.length - 1]?.dataset.color || "#FFFFFF")) {
+                emit();
+            }
             updateControls();
         })
         : null;


### PR DESCRIPTION
## Summary
- make custom pointerup buttons respect disabled state
- prevent dynamic element palette swatches from exceeding the backend limit
- emit palette changes only when a swatch was actually added

## Tests
- node --check js/*.js