### PR TITLE
Add Ideogram4 T2I LoRA slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [Unreleased]
+
+### Added
+- `toobusy Ideogram4 T2I`에 Z-Image Turbo와 같은 최대 5개 **LoRA 슬롯**을 추가했습니다.
+  활성화된 슬롯은 `LoraLoader` 체인으로 conditional 모델과 CLIP에 순서대로 적용되며,
+  `ideogram4_unconditional` 모델은 원본 checkpoint를 유지합니다.
+
 ## [0.2.6] - 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 | 노드 | Before (직접 배선) | After |
 |---|---|---|
 | **Z-Image Turbo** | UNET·CLIP·VAE 로더 + (LoRA×N) + ModelSamplingAuraFlow + CLIPTextEncode×2 + EmptyLatentImage + KSampler + VAEDecode — 약 10노드 | **1 노드** |
-| **Ideogram4 T2I** | 로더 4 + 인코딩 + ConditioningZeroOut + CFGOverride + DualModelGuider + RandomNoise + KSamplerSelect + Ideogram4Scheduler + EmptyLatent + SamplerCustomAdvanced + VAEDecode — 약 13노드 | **1 노드** |
+| **Ideogram4 T2I** | 로더 4 + 선택적 LoRA 체인 + 인코딩 + ConditioningZeroOut + CFGOverride + DualModelGuider + RandomNoise + KSamplerSelect + Ideogram4Scheduler + EmptyLatent + SamplerCustomAdvanced + VAEDecode — 약 13노드+ | **1 노드** |
 | **LTX2.3 Compact AV Sampler** | RandomNoise + ConcatAVLatent + CFGGuider + KSamplerSelect + ManualSigmas + SamplerCustomAdvanced + SeparateAVLatent + CropGuides — 8노드 | **1 노드** |
 | **LTX2.3 Empty AV Latents** | EmptyLTXVLatentVideo + LTXVEmptyLatentAudio (+커스텀 오디오: AudioVAEEncode + SolidMask + SetLatentNoiseMask) | **1 노드** |
 | **Keyframe Maker** | 브리프 → 샷 비트 → 비주얼 앵커 → 키프레임 → 스토리, 5단계 수동 프롬프팅 | **1 노드** |
@@ -374,7 +374,10 @@ RandomNoise -> LTXVConcatAVLatent -> CFGGuider -> KSamplerSelect -> ManualSigmas
   레이아웃 품질을 우선해 2K 정사각형(`2048 x 2048`)입니다.
 - `ideogram4_t2i_node` (`toobusy Ideogram4 T2I`) — 프롬프트로부터 로컬 Ideogram 4
   모델(CLIP `ideogram4`, `Ideogram4Scheduler`)을 실행합니다. Layout Builder의 JSON
-  프롬프트와 `width`/`height`를 그대로 받습니다.
+  프롬프트와 `width`/`height`를 그대로 받습니다. Z-Image Turbo와 같은 방식의
+  **LoRA 슬롯**을 제공하며, `Add LoRA slot` / `Remove LoRA slot`으로 최대 5개까지
+  표시할 수 있습니다. 활성화된 슬롯은 conditional 모델과 CLIP에 순서대로 적용되고,
+  `ideogram4_unconditional` 모델은 원래 checkpoint를 유지합니다.
 
 ## 로드맵
 

--- a/ideogram4_t2i_node/ideogram4_t2i.py
+++ b/ideogram4_t2i_node/ideogram4_t2i.py
@@ -15,6 +15,8 @@ RATIO_PRESETS = {
     "9:21": (9, 21),
 }
 
+MAX_LORA_SLOTS = 5
+
 # Ideogram 4 sampling presets (steps, mu, std) — values taken from the official
 # Ideogram4 text-to-image workflow's preset table.
 QUALITY_PRESETS = {
@@ -76,6 +78,10 @@ def _vae_names():
     return _folder_list("vae", ["flux2-vae.safetensors"])
 
 
+def _lora_names():
+    return ["None"] + _folder_list("loras", [])
+
+
 def _round_to_16(value):
     return max(256, min(2048, int(round(value / 16)) * 16))
 
@@ -101,9 +107,10 @@ class ToobusyIdeogram4T2I:
         diffusion_names = _diffusion_model_names()
         clip_names = _clip_names()
         vae_names = _vae_names()
+        lora_names = _lora_names()
         sampler_names = _sampler_names()
 
-        return {
+        inputs = {
             "required": {
                 "model_name": (
                     diffusion_names,
@@ -136,6 +143,7 @@ class ToobusyIdeogram4T2I:
                     {"default": "res_multistep" if "res_multistep" in sampler_names else sampler_names[0]},
                 ),
                 "cfg": ("FLOAT", {"default": 7.0, "min": 0.0, "max": 100.0, "step": 0.1}),
+                "lora_slots": ("INT", {"default": 0, "min": 0, "max": MAX_LORA_SLOTS}),
             },
             "optional": {
                 "width": (
@@ -156,6 +164,17 @@ class ToobusyIdeogram4T2I:
             },
         }
 
+        required = inputs["required"]
+        for slot in range(1, MAX_LORA_SLOTS + 1):
+            required[f"lora_{slot}_enable"] = ("BOOLEAN", {"default": False})
+            required[f"lora_{slot}_name"] = (lora_names, {"default": "None"})
+            required[f"lora_{slot}_strength"] = (
+                "FLOAT",
+                {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01},
+            )
+
+        return inputs
+
     RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT")
     RETURN_NAMES = ("image", "latent", "width", "height")
     FUNCTION = "generate"
@@ -175,6 +194,7 @@ class ToobusyIdeogram4T2I:
         seed,
         sampler_name,
         cfg,
+        lora_slots,
         width=0,
         height=0,
         mu=0.5,
@@ -182,6 +202,7 @@ class ToobusyIdeogram4T2I:
         cfg_override=3.0,
         cfg_override_start=0.9,
         cfg_override_end=1.0,
+        **lora_kwargs,
     ):
         if quality == "Custom":
             preset_steps = int(steps) if int(steps) > 0 else 20
@@ -205,6 +226,21 @@ class ToobusyIdeogram4T2I:
         model_uncond = _call_node("UNETLoader", unet_name=unconditional_model_name, weight_dtype="default")[0]
         clip = _call_node("CLIPLoader", clip_name=clip_name, type="ideogram4", device="default")[0]
         vae = _call_node("VAELoader", vae_name=vae_name)[0]
+
+        lora_slots = max(0, min(MAX_LORA_SLOTS, int(lora_slots)))
+        for slot in range(1, lora_slots + 1):
+            enabled = lora_kwargs.get(f"lora_{slot}_enable", False)
+            lora_name = lora_kwargs.get(f"lora_{slot}_name", "None")
+            lora_strength = float(lora_kwargs.get(f"lora_{slot}_strength", 1.0))
+            if enabled and lora_name != "None":
+                model, clip = _call_node(
+                    "LoraLoader",
+                    model=model,
+                    clip=clip,
+                    lora_name=lora_name,
+                    strength_model=lora_strength,
+                    strength_clip=lora_strength,
+                )
 
         # Conditioning (asymmetric CFG: negative is a zeroed-out copy of positive)
         positive = _call_node("CLIPTextEncode", clip=clip, text=prompt)[0]

--- a/js/toobusy_ideogram4_t2i.js
+++ b/js/toobusy_ideogram4_t2i.js
@@ -1,0 +1,103 @@
+import { app } from "../../scripts/app.js";
+
+const MAX_LORA_SLOTS = 5;
+
+function findWidget(node, name) {
+    return node.widgets?.find((widget) => widget.name === name);
+}
+
+function setWidgetVisible(node, widget, visible) {
+    if (!widget) return;
+
+    if (!widget._toobusyOriginalType) {
+        widget._toobusyOriginalType = widget.type;
+        widget._toobusyOriginalComputeSize = widget.computeSize;
+    }
+
+    widget.hidden = !visible;
+    widget.disabled = !visible;
+    widget.type = visible ? widget._toobusyOriginalType : "hidden";
+    widget.computeSize = visible ? widget._toobusyOriginalComputeSize : () => [0, -4];
+    node.setDirtyCanvas?.(true, true);
+}
+
+function loraSlotWidgets(node, slot) {
+    return [
+        findWidget(node, `lora_${slot}_enable`),
+        findWidget(node, `lora_${slot}_name`),
+        findWidget(node, `lora_${slot}_strength`),
+    ];
+}
+
+function activeSlotCount(node) {
+    const widget = findWidget(node, "lora_slots");
+    const value = Number(widget?.value ?? 0);
+    return Math.max(0, Math.min(MAX_LORA_SLOTS, Number.isFinite(value) ? Math.round(value) : 0));
+}
+
+function setActiveSlotCount(node, count) {
+    const clamped = Math.max(0, Math.min(MAX_LORA_SLOTS, count));
+    const widget = findWidget(node, "lora_slots");
+    if (widget) widget.value = clamped;
+    updateLoraSlots(node);
+}
+
+function updateLoraSlots(node) {
+    const count = activeSlotCount(node);
+    for (let slot = 1; slot <= MAX_LORA_SLOTS; slot += 1) {
+        const visible = slot <= count;
+        for (const widget of loraSlotWidgets(node, slot)) {
+            setWidgetVisible(node, widget, visible);
+        }
+    }
+
+    if (node._toobusyAddLoraBtn) {
+        node._toobusyAddLoraBtn.name = count >= MAX_LORA_SLOTS ? "LoRA slots full" : "Add LoRA slot";
+    }
+    if (node._toobusyRemoveLoraBtn) {
+        node._toobusyRemoveLoraBtn.name = count <= 0 ? "No LoRA slots" : "Remove LoRA slot";
+    }
+
+    node.setDirtyCanvas?.(true, true);
+    app.graph?.setDirtyCanvas?.(true, true);
+}
+
+app.registerExtension({
+    name: "toobusy.ideogram4T2I",
+    beforeRegisterNodeDef(nodeType, nodeData) {
+        if (nodeData.name !== "ToobusyIdeogram4T2I") return;
+
+        const onNodeCreated = nodeType.prototype.onNodeCreated;
+        nodeType.prototype.onNodeCreated = function () {
+            onNodeCreated?.apply(this, arguments);
+
+            const slotWidget = findWidget(this, "lora_slots");
+            if (slotWidget) {
+                setWidgetVisible(this, slotWidget, false);
+                const callback = slotWidget.callback;
+                slotWidget.callback = (...args) => {
+                    callback?.apply(slotWidget, args);
+                    updateLoraSlots(this);
+                };
+            }
+
+            this._toobusyAddLoraBtn = this.addWidget("button", "Add LoRA slot", "add", () => {
+                if (activeSlotCount(this) >= MAX_LORA_SLOTS) return;
+                setActiveSlotCount(this, activeSlotCount(this) + 1);
+            }, { serialize: false });
+
+            this._toobusyRemoveLoraBtn = this.addWidget("button", "No LoRA slots", "remove", () => {
+                if (activeSlotCount(this) <= 0) return;
+                setActiveSlotCount(this, activeSlotCount(this) - 1);
+            }, { serialize: false });
+
+            updateLoraSlots(this);
+        };
+
+        const onConfigure = nodeType.prototype.onConfigure;
+        nodeType.prototype.onConfigure = function () {
+            onConfigure?.apply(this, arguments);
+            updateLoraSlots(this);
+        };
+    },
+});


### PR DESCRIPTION
## Summary
- add optional LoRA slot inputs to ToobusyIdeogram4T2I
- apply enabled slots through ComfyUI LoraLoader on the conditional model and ideogram4 CLIP
- add Add/Remove LoRA slot UI controls mirroring Z-Image Turbo
- document the Ideogram4 LoRA behavior in README and CHANGELOG

## Tests
- node --check js/*.js
- python -m compileall -q __init__.py hf_model_auto_loader ideogram4_t2i_node ideogram_layout_builder ideogram_prompt_polish_node keyframe_maker_node ltx23_compact_sampler_node storyboard_board_node z_image_turbo_node