### PR TITLE
Z-Image Turbo: 슬롯별 LoRA 삭제 (Ideogram4와 통일)

### DIFF
--- a/js/toobusy_z_image_turbo.js
+++ b/js/toobusy_z_image_turbo.js
@@ -88,7 +88,43 @@ function loraSlotWidgets(node, slot) {
         findWidget(node, `lora_${slot}_enable`),
         findWidget(node, `lora_${slot}_name`),
         findWidget(node, `lora_${slot}_strength`),
+        node[`_toobusyRemoveLora${slot}`],
     ];
+}
+
+// Copy one slot's three values into another (compact slots upward on remove).
+function copyLoraSlot(node, from, to) {
+    for (const field of ["enable", "name", "strength"]) {
+        const src = findWidget(node, `lora_${from}_${field}`);
+        const dst = findWidget(node, `lora_${to}_${field}`);
+        if (src && dst) {
+            dst.value = src.value;
+            dst.callback?.(dst.value);
+        }
+    }
+}
+
+function clearLoraSlot(node, slot) {
+    const defaults = { enable: false, name: "None", strength: 1.0 };
+    for (const [field, value] of Object.entries(defaults)) {
+        const widget = findWidget(node, `lora_${slot}_${field}`);
+        if (widget) {
+            widget.value = value;
+            widget.callback?.(value);
+        }
+    }
+}
+
+// Remove a specific slot: slots below shift up, the freed last slot is reset,
+// and the active count drops by one.
+function removeLoraSlot(node, slot) {
+    const count = activeSlotCount(node);
+    if (slot < 1 || slot > count) return;
+    for (let k = slot; k < count; k += 1) {
+        copyLoraSlot(node, k + 1, k);
+    }
+    clearLoraSlot(node, count);
+    setActiveSlotCount(node, count - 1);
 }
 
 function activeSlotCount(node) {
@@ -118,9 +154,9 @@ function updateLoraSlots(node) {
         }
     }
 
-    // The Add/Remove LoRA buttons belong to the Advanced view too.
+    // The Add LoRA button belongs to the Advanced view too. Per-slot remove
+    // buttons are gated via loraSlotWidgets above (advanced && slot <= count).
     setWidgetVisible(node, node._toobusyAddBtn, advanced);
-    setWidgetVisible(node, node._toobusyRemoveBtn, advanced);
     if (node._toobusyAddBtn) {
         node._toobusyAddBtn.name = count >= MAX_LORA_SLOTS ? "LoRA slots full" : "Add LoRA slot";
     }
@@ -179,12 +215,24 @@ app.registerExtension({
                 };
             }
 
-            this._toobusyAddBtn = this.addWidget("button", "Add LoRA slot", "add", () => {
-                setActiveSlotCount(this, activeSlotCount(this) + 1);
-            }, { serialize: false });
+            // Per-slot remove button under each slot, so you remove the LoRA you
+            // see (not just the last one). Slots below shift up on remove.
+            for (let slot = 1; slot <= MAX_LORA_SLOTS; slot += 1) {
+                const button = this.addWidget("button", `✕ Remove LoRA ${slot}`, "remove", () => {
+                    removeLoraSlot(this, slot);
+                }, { serialize: false });
+                this[`_toobusyRemoveLora${slot}`] = button;
+                const widgets = this.widgets;
+                const fromIndex = widgets.indexOf(button);
+                if (fromIndex >= 0) widgets.splice(fromIndex, 1);
+                const strength = findWidget(this, `lora_${slot}_strength`);
+                const insertAt = strength ? widgets.indexOf(strength) + 1 : widgets.length;
+                widgets.splice(insertAt, 0, button);
+            }
 
-            this._toobusyRemoveBtn = this.addWidget("button", "Remove LoRA slot", "remove", () => {
-                setActiveSlotCount(this, activeSlotCount(this) - 1);
+            this._toobusyAddBtn = this.addWidget("button", "Add LoRA slot", "add", () => {
+                if (activeSlotCount(this) >= MAX_LORA_SLOTS) return;
+                setActiveSlotCount(this, activeSlotCount(this) + 1);
             }, { serialize: false });
 
             this._toobusyAdvButton = this.addWidget("button", "Show advanced settings", "advanced", () => {


### PR DESCRIPTION
같은 LoRA 슬롯 패턴이라 같은 불편함이 있었음. 전역 Remove(마지막만 숨김+값 잔존) → 슬롯별 '✕ Remove LoRA N'(아래로 compact + 마지막 리셋). Basic/Advanced 게이팅 존중(advanced에서만 표시). Add 유지. JS only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)