### PR TITLE
Add override regression tests + docs, wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,13 @@ jobs:
             hf_model_auto_loader \
             ideogram4_t2i_node \
             ideogram_layout_builder \
+            ideogram_prompt_polish_node \
             keyframe_maker_node \
             ltx23_compact_sampler_node \
             storyboard_board_node \
             z_image_turbo_node
+      - name: Override input regression tests (no ComfyUI runtime)
+        run: python tests/test_model_overrides.py
 
   js-syntax:
     name: Frontend JS syntax

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ __pycache__/
 
 # Private local Crux <-> Coda collaboration notes (never published).
 AGENT_MAILBOX.md
+AGENT_STATE.md
 CODA_HANDOFF.md
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [Unreleased]
+
+### Added
+- `toobusy Z-Image Turbo`와 `toobusy Ideogram4 T2I`에 **외부 모델 override 입력**을
+  추가했습니다(Z-Image: `model/clip/vae_override`, Ideogram4: `model/uncond_model/clip/vae_override`).
+  연결된 override는 해당 내부 로더(`UNETLoader`/`CLIPLoader`/`VAELoader`)를 건너뛰고,
+  비워 두면 기존처럼 이름 위젯으로 내부 로드합니다. GGUF 등 다른 로더의 MODEL/CLIP/VAE를
+  결합 없이 흘려보낼 수 있습니다. (PR #33)
+- override INPUT_TYPES 노출과 loader-skip 동작을 검증하는 회귀 테스트
+  `tests/test_model_overrides.py`를 추가하고 CI에서 실행합니다(ComfyUI 런타임 불필요).
+
+### Fixed
+- CI byte-compile 목록에서 빠져 있던 `ideogram_prompt_polish_node`를 추가했습니다.
+
 ## [0.2.7] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 
 한국어 장면을 입력하면, Ideogram용 구조화 프롬프트로 정리하고, Layout Builder에서 박스와 구도를 확인한 뒤, 로컬 Ideogram4 모델로 이미지를 생성하는 흐름입니다.
 
+`toobusy Ideogram4 T2I`도 선택형 외부 모델 override 입력을 받습니다: `model_override`·`uncond_model_override`(MODEL), `clip_override`(CLIP), `vae_override`(VAE). 연결된 소켓은 해당 내부 로더를 건너뛰고(미연결 시 `model_name`/`unconditional_model_name`/`clip_name`/`vae_name`으로 내부 로드), GGUF 등 다른 로더의 모델을 그대로 사용할 수 있습니다.
+
 함께 쓰기 좋은 노드:
 
 - `toobusy Keyframe Maker`
@@ -267,6 +269,7 @@ UNETLoader + CLIPLoader + VAELoader
 - `ratio_preset`, `megapixels`, `divisible_by`: 종횡비와 목표 메가픽셀로부터 해상도를 계산합니다.
 - `seed`, `steps`, `cfg`, `sampler_name`, `scheduler`, `denoise`, `aura_shift`.
 - LoRA 슬롯: 프런트엔드에 `Add LoRA slot` / `Remove LoRA slot` 버튼이 추가됩니다. 최대 5개 슬롯까지 표시할 수 있으며, 각 슬롯은 자체 활성화 토글, LoRA 파일, 강도를 가집니다.
+- 외부 모델 override(선택): `model_override`(MODEL), `clip_override`(CLIP), `vae_override`(VAE) 입력 소켓입니다. 연결하면 해당 내부 로더(`UNETLoader`/`CLIPLoader`/`VAELoader`)를 건너뛰고 연결된 객체를 그대로 사용하고, 비워 두면 위의 `model_name`/`clip_name`/`vae_name`으로 내부 로드합니다. GGUF 등 다른 로더로 불러온 모델을 그대로 흘려보낼 때 유용합니다.
 
 LoRA 동작:
 

--- a/tests/test_model_overrides.py
+++ b/tests/test_model_overrides.py
@@ -1,0 +1,172 @@
+"""Regression tests for the external MODEL/CLIP/VAE override inputs on the
+folded samplers (Ideogram4 T2I, Z-Image Turbo).
+
+These nodes normally load UNET/CLIP/VAE internally. The override inputs let an
+advanced user feed pre-built MODEL/CLIP/VAE objects from any compatible loader;
+when an override is connected the matching internal loader must be skipped.
+
+The test loads the node modules standalone (no running ComfyUI) by stubbing
+``folder_paths`` and the shared ``_call_node`` helper, then asserts:
+  1. the override keys are exposed in ``INPUT_TYPES()["optional"]`` with the
+     right socket type, and
+  2. ``generate()`` skips the internal loader for each connected override and
+     still runs every internal loader when no override is connected.
+
+Runs under pytest (``test_*`` functions) and standalone
+(``python tests/test_model_overrides.py``) so it works in this repo's
+compile-only CI without adding a pytest dependency.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Internal loader node types that an override must bypass.
+LOADER_NODES = ("UNETLoader", "CLIPLoader", "VAELoader")
+
+# Shared call log populated by the stubbed _call_node.
+_CALLS = []
+
+
+def _install_stubs():
+    """Stub the ComfyUI runtime so the node modules import standalone."""
+    folder_paths = types.ModuleType("folder_paths")
+    folder_paths.get_filename_list = lambda kind: []
+    sys.modules["folder_paths"] = folder_paths
+
+    def fake_call_node(node_type, **kwargs):
+        _CALLS.append(node_type)
+        return [f"<{node_type}-out>"]
+
+    pkg = types.ModuleType("toobusy")
+    pkg.__path__ = [ROOT]
+    sys.modules["toobusy"] = pkg
+
+    sub = types.ModuleType("toobusy.ltx23_compact_sampler_node")
+    sub.__path__ = [os.path.join(ROOT, "ltx23_compact_sampler_node")]
+    sys.modules["toobusy.ltx23_compact_sampler_node"] = sub
+
+    samp = types.ModuleType("toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler")
+    samp._call_node = fake_call_node
+    samp._sampler_names = lambda: ["res_multistep", "euler"]
+    samp._default_sampler_name = lambda names: names[0]
+    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
+
+
+def _load(modname, relpath):
+    path = os.path.join(ROOT, relpath)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_stubs()
+_ideo = _load(
+    "toobusy.ideogram4_t2i_node.ideogram4_t2i",
+    os.path.join("ideogram4_t2i_node", "ideogram4_t2i.py"),
+)
+_zit = _load(
+    "toobusy.z_image_turbo_node.z_image_turbo",
+    os.path.join("z_image_turbo_node", "z_image_turbo.py"),
+)
+
+
+def _loaders_called():
+    return [c for c in _CALLS if c in LOADER_NODES]
+
+
+# --- INPUT_TYPES exposure -------------------------------------------------
+
+def test_zimage_exposes_override_inputs():
+    optional = _zit.ToobusyZImageTurbo.INPUT_TYPES()["optional"]
+    assert optional.get("model_override") == ("MODEL",)
+    assert optional.get("clip_override") == ("CLIP",)
+    assert optional.get("vae_override") == ("VAE",)
+
+
+def test_ideogram4_exposes_override_inputs():
+    optional = _ideo.ToobusyIdeogram4T2I.INPUT_TYPES()["optional"]
+    assert optional.get("model_override") == ("MODEL",)
+    assert optional.get("uncond_model_override") == ("MODEL",)
+    assert optional.get("clip_override") == ("CLIP",)
+    assert optional.get("vae_override") == ("VAE",)
+
+
+# --- loader-skip behaviour ------------------------------------------------
+
+def _run_zimage(**overrides):
+    _CALLS.clear()
+    _zit.ToobusyZImageTurbo().generate(
+        model_name="m", clip_name="c", vae_name="v", positive="p", negative="n",
+        ratio_preset="1:1", megapixels=1.0, divisible_by=32, batch_size=1, seed=1,
+        steps=8, cfg=1.0, sampler_name="res_multistep", scheduler="simple",
+        denoise=1.0, aura_shift=3.0, lora_slots=0, **overrides,
+    )
+
+
+def _run_ideogram4(**overrides):
+    _CALLS.clear()
+    _ideo.ToobusyIdeogram4T2I().generate(
+        model_name="m", unconditional_model_name="um", clip_name="c", vae_name="v",
+        prompt="{}", quality="Turbo", steps=0, ratio_preset="1:1", megapixels=1.0,
+        seed=0, sampler_name="res_multistep", cfg=7.0, lora_slots=0, **overrides,
+    )
+
+
+def test_zimage_overrides_skip_internal_loaders():
+    _run_zimage(
+        model_override="EXT_M", clip_override="EXT_C", vae_override="EXT_V",
+    )
+    assert _loaders_called() == [], "override connected but internal loaders ran"
+
+
+def test_zimage_no_override_runs_all_loaders():
+    _run_zimage()
+    assert sorted(_loaders_called()) == sorted(LOADER_NODES)
+
+
+def test_ideogram4_overrides_skip_internal_loaders():
+    _run_ideogram4(
+        model_override="EXT_M", uncond_model_override="EXT_UM",
+        clip_override="EXT_C", vae_override="EXT_V",
+    )
+    assert _loaders_called() == [], "override connected but internal loaders ran"
+
+
+def test_ideogram4_no_override_runs_all_loaders():
+    _run_ideogram4()
+    # Ideogram4 loads two UNETs (conditional + unconditional) plus CLIP + VAE.
+    called = _loaders_called()
+    assert called.count("UNETLoader") == 2
+    assert called.count("CLIPLoader") == 1
+    assert called.count("VAELoader") == 1
+
+
+def test_ideogram4_partial_override_skips_only_connected():
+    # Only the conditional model is overridden; the other three loaders run.
+    _run_ideogram4(model_override="EXT_M")
+    called = _loaders_called()
+    assert called.count("UNETLoader") == 1  # only the unconditional UNET loads
+    assert called.count("CLIPLoader") == 1
+    assert called.count("VAELoader") == 1
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    if failures:
+        print(f"\n{failures} test(s) failed")
+        sys.exit(1)
+    print("\nall tests passed")


### PR DESCRIPTION
## 배경
PR #33에서 추가된 외부 MODEL/CLIP/VAE override 입력은 자동 테스트도, 문서도 없었습니다. 운영자 검수 요청에 따라 회귀 보호와 문서를 보강합니다. (코드 동작 자체는 PR #33에서 이미 검증됨)

## 변경
- **테스트**: `tests/test_model_overrides.py` 신규. pytest / 단독 실행(`python tests/test_model_overrides.py`) 모두 가능하고 ComfyUI 런타임이 필요 없습니다. 검증 항목:
  - override 키가 `INPUT_TYPES()[optional]`에 올바른 소켓 타입으로 노출
  - 연결된 override는 해당 내부 로더(`UNETLoader`/`CLIPLoader`/`VAELoader`)를 skip
  - 미연결 시 내부 로더 정상 실행, 부분 override 시 연결된 것만 skip (총 7 케이스)
- **CI**: python-compile 잡에 위 테스트 실행 스텝 추가. 더불어 compileall 목록에서 빠져 있던 `ideogram_prompt_polish_node` 보충(기존 AGENT_STATE CI TODO 해소).
- **문서**: README(Z-Image Turbo·Ideogram4 T2I override 입력 설명) + CHANGELOG `[Unreleased]` 기재.
- **잡일**: 로컬 전용 보드 `AGENT_STATE.md`를 `.gitignore`에 추가(privacy TODO 해소).

## 테스트
- 로컬: `python tests/test_model_overrides.py` → 7개 전부 PASS.

## 릴리스
버전 bump / 태그 / Registry 발행 **없음** — `[Unreleased]`로만 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)