### PR TITLE
Z-Image Turbo: direct width/height + img2img image input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,12 @@ jobs:
             ltx23_compact_sampler_node \
             storyboard_board_node \
             z_image_turbo_node
-      - name: Override input regression tests (no ComfyUI runtime)
-        run: python tests/test_model_overrides.py
+      - name: Node behaviour regression tests (no ComfyUI runtime)
+        run: |
+          for f in tests/test_*.py; do
+            echo "== $f =="
+            python "$f"
+          done
 
   js-syntax:
     name: Frontend JS syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@
   연결된 override는 해당 내부 로더(`UNETLoader`/`CLIPLoader`/`VAELoader`)를 건너뛰고,
   비워 두면 기존처럼 이름 위젯으로 내부 로드합니다. GGUF 등 다른 로더의 MODEL/CLIP/VAE를
   결합 없이 흘려보낼 수 있습니다. (PR #33)
-- override INPUT_TYPES 노출과 loader-skip 동작을 검증하는 회귀 테스트
-  `tests/test_model_overrides.py`를 추가하고 CI에서 실행합니다(ComfyUI 런타임 불필요).
+- `toobusy Z-Image Turbo`에 **직접 해상도 입력**(`width`/`height`)을 추가했습니다. 둘 다
+  `> 0`이면 `ratio_preset`+`megapixels` 대신 그 값을 사용합니다(`divisible_by`로 반올림).
+- `toobusy Z-Image Turbo`에 **img2img 자동 전환**을 추가했습니다. 선택형 `image` 입력을
+  연결하면 `VAEEncode`로 시작 latent을 만들고(`EmptyLatentImage` 대신) `denoise`가 변환
+  강도가 됩니다. `width`/`height` 지정 시 소스를 그 크기로 스케일(center crop), 미지정 시
+  소스 크기를 따릅니다. 해상도 미리보기 위젯이 t2i/img2img·manual 상태를 표시합니다.
+- override / 해상도 / img2img 동작을 검증하는 회귀 테스트
+  `tests/test_model_overrides.py`, `tests/test_zimage_resolution_i2i.py`를 추가하고
+  CI에서 `tests/test_*.py`를 자동 검출해 실행합니다(ComfyUI 런타임 불필요).
 
 ### Fixed
 - CI byte-compile 목록에서 빠져 있던 `ideogram_prompt_polish_node`를 추가했습니다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   `tests/test_model_overrides.py`, `tests/test_zimage_resolution_i2i.py`를 추가하고
   CI에서 `tests/test_*.py`를 자동 검출해 실행합니다(ComfyUI 런타임 불필요).
 
+### Changed
+- `toobusy Z-Image Turbo`의 **Basic/Advanced 구성을 재정비**했습니다. 모델 로드 슬롯
+  (`model_name`/`clip_name`/`vae_name`)을 **기본 노출**해 초보자가 어떤 모델이 물렸는지
+  바로 확인할 수 있게 했고(Advanced에 숨기지 않음), Advanced에는 expert 튜닝
+  (`divisible_by`/`cfg`/`sampler_name`/`scheduler`/`denoise`/`aura_shift`)과 LoRA만 남겼습니다.
+- 항상 떠 있던 2줄 `folds` 설명 텍스트를 **노드 우상단 `i` info 배지 + 호버 툴팁**으로
+  교체했습니다(노드 화면을 덜 어지럽게).
+
 ### Fixed
 - CI byte-compile 목록에서 빠져 있던 `ideogram_prompt_polish_node`를 추가했습니다.
 

--- a/README.md
+++ b/README.md
@@ -282,9 +282,10 @@ LoRA 동작:
 
 Basic / Advanced:
 
-- 기본은 **Basic 화면**으로, 자주 쓰는 입력만 보입니다: `positive`, `negative`, `ratio_preset`, `megapixels`, `batch_size`, `seed`, `steps`.
-- `Show advanced settings` 버튼을 누르면 expert 컨트롤(`model_name`, `clip_name`, `vae_name`, `divisible_by`, `cfg`, `sampler_name`, `scheduler`, `denoise`, `aura_shift`)과 LoRA 슬롯/버튼이 나타납니다. 상태는 노드에 저장되어 그래프를 다시 열어도 유지됩니다.
-- **해상도 미리보기**: `ratio_preset @ megapixels -> 가로 x 세로` 표시 위젯이 항상 보여, 큐에 올리기 전에 실제 생성 크기를 확인할 수 있습니다.
+- 기본은 **Basic 화면**으로, 자주 쓰는 입력이 보입니다: **`model_name`/`clip_name`/`vae_name`(모델 로드 슬롯)**, `positive`, `negative`, `ratio_preset`, `megapixels`, `width`, `height`, `batch_size`, `seed`, `steps`. 모델 로드 슬롯을 기본 노출해, 어떤 모델이 물려 있는지 바로 보고 고칠 수 있습니다(엉뚱한 모델로 헤매는 상황 방지).
+- `Show advanced settings` 버튼을 누르면 expert 튜닝 컨트롤(`divisible_by`, `cfg`, `sampler_name`, `scheduler`, `denoise`, `aura_shift`)과 LoRA 슬롯/버튼이 나타납니다. 상태는 노드에 저장되어 그래프를 다시 열어도 유지됩니다.
+- **info 배지**: 노드 우상단 모서리의 `i` 아이콘에 마우스를 올리면, 이 노드가 어떤 노드들을 접는지(t2i/img2img 흐름 포함) 설명 툴팁이 뜹니다.
+- **해상도 미리보기**: `ratio_preset @ megapixels -> 가로 x 세로`(직접 입력 시 `manual -> ...`, 이미지 연결 시 `img2img -> ...`) 표시 위젯이 항상 보여, 큐에 올리기 전에 실제 생성 크기를 확인할 수 있습니다.
 
 출력:
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ UNETLoader + CLIPLoader + VAELoader
 -> 선택적 LoraLoader 슬롯 체인
 -> ModelSamplingAuraFlow
 -> CLIPTextEncode positive/negative
--> EmptyLatentImage
+-> EmptyLatentImage  (image 입력이 없을 때 · t2i)
+   또는 (선택) ImageScale -> VAEEncode  (image 입력이 있을 때 · img2img)
 -> KSampler
 -> VAEDecode
 ```
@@ -267,6 +268,8 @@ UNETLoader + CLIPLoader + VAELoader
 - `vae_name`: VAE 파일. 예: `FLUX1\ae.safetensors`.
 - `positive` / `negative`: 프롬프트 텍스트.
 - `ratio_preset`, `megapixels`, `divisible_by`: 종횡비와 목표 메가픽셀로부터 해상도를 계산합니다.
+- `width` / `height`(선택): 직접 입력 칸. 둘 다 `0`이면 위 `ratio_preset`+`megapixels`로 계산하고, 둘 다 `> 0`이면 그 해상도를 직접 사용합니다(`divisible_by`로 반올림). 해상도 미리보기 위젯에 `manual -> 가로 x 세로`로 표시됩니다.
+- `image`(선택, IMAGE 소켓): **연결하면 자동으로 img2img로 전환**됩니다. 이미지를 `VAEEncode`로 인코딩해 시작 latent으로 쓰고, `denoise`가 변환 강도가 됩니다(낮을수록 원본 보존). `width`/`height`를 지정하면 소스를 그 크기로 스케일(center crop)하고, 비워 두면 소스 이미지 크기를 그대로 따릅니다. 소켓을 비우면 기존 t2i로 동작합니다.
 - `seed`, `steps`, `cfg`, `sampler_name`, `scheduler`, `denoise`, `aura_shift`.
 - LoRA 슬롯: 프런트엔드에 `Add LoRA slot` / `Remove LoRA slot` 버튼이 추가됩니다. 최대 5개 슬롯까지 표시할 수 있으며, 각 슬롯은 자체 활성화 토글, LoRA 파일, 강도를 가집니다.
 - 외부 모델 override(선택): `model_override`(MODEL), `clip_override`(CLIP), `vae_override`(VAE) 입력 소켓입니다. 연결하면 해당 내부 로더(`UNETLoader`/`CLIPLoader`/`VAELoader`)를 건너뛰고 연결된 객체를 그대로 사용하고, 비워 두면 위의 `model_name`/`clip_name`/`vae_name`으로 내부 로드합니다. GGUF 등 다른 로더로 불러온 모델을 그대로 흘려보낼 때 유용합니다.

--- a/js/toobusy_z_image_turbo.js
+++ b/js/toobusy_z_image_turbo.js
@@ -2,13 +2,14 @@ import { app } from "../../scripts/app.js";
 
 const MAX_LORA_SLOTS = 5;
 
-// Expert controls hidden by default (Basic view). Everything not listed here —
-// positive, negative, ratio_preset, megapixels, batch_size, seed, steps — plus
-// the LoRA controls (handled separately) make up the Basic surface.
+// Expert tuning hidden by default (Basic view). The model-load slots
+// (model_name / clip_name / vae_name) are intentionally NOT here: they stay
+// visible so a beginner can see and fix which model is loaded instead of
+// wiring the wrong file and wondering why nothing works. Everything not listed
+// here — model/clip/vae names, positive, negative, ratio_preset, megapixels,
+// width, height, batch_size, seed, steps — plus the LoRA controls (handled
+// separately) make up the Basic surface.
 const ADVANCED_WIDGETS = [
-    "model_name",
-    "clip_name",
-    "vae_name",
     "divisible_by",
     "cfg",
     "sampler_name",
@@ -16,6 +17,13 @@ const ADVANCED_WIDGETS = [
     "denoise",
     "aura_shift",
 ];
+
+// Shown in the hover tooltip behind the top-right info badge (replaces the old
+// always-on "folds" text row).
+const INFO_TEXT =
+    "Folds ~10 nodes into one: UNET + CLIP + VAE loaders + (LoRA) -> " +
+    "ModelSamplingAuraFlow -> CLIPTextEncode x2 -> EmptyLatentImage " +
+    "(or VAEEncode when an image is connected, i.e. img2img) -> KSampler -> VAEDecode.";
 
 // Mirror of z_image_turbo.py RATIO_PRESETS / _resolution_from_megapixels so the
 // node can show the dimensions it will generate before the graph is queued.
@@ -38,6 +46,87 @@ function resolutionFromMegapixels(ratioPreset, megapixels, divisibleBy) {
 
 function findWidget(node, name) {
     return node.widgets?.find((widget) => widget.name === name);
+}
+
+function titleHeight() {
+    return (typeof LiteGraph !== "undefined" && LiteGraph.NODE_TITLE_HEIGHT) || 30;
+}
+
+// Greedy word-wrap of `text` into lines no wider than `maxWidth` for `ctx`'s
+// current font.
+function wrapText(ctx, text, maxWidth) {
+    const lines = [];
+    let line = "";
+    for (const word of String(text).split(/\s+/)) {
+        const test = line ? `${line} ${word}` : word;
+        if (line && ctx.measureText(test).width > maxWidth) {
+            lines.push(line);
+            line = word;
+        } else {
+            line = test;
+        }
+    }
+    if (line) lines.push(line);
+    return lines;
+}
+
+// Draw a small "i" badge in the node's top-right title corner, and — while
+// hovered — a tooltip box with INFO_TEXT. Stores the badge's hit-circle on the
+// node so onMouseMove can detect hover. Guarded so a draw error can never break
+// the rest of the node.
+function drawInfoBadge(node, ctx) {
+    if (node.flags && node.flags.collapsed) {
+        node._toobusyInfoRect = null;
+        return;
+    }
+    const r = 7;
+    const cx = node.size[0] - 15;
+    const cy = -titleHeight() * 0.5;
+    node._toobusyInfoRect = { cx, cy, r };
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.fillStyle = node._toobusyInfoHover ? "#5b9dff" : "#6b7785";
+    ctx.fill();
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "bold 10px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("i", cx, cy + 0.5);
+    ctx.restore();
+
+    if (!node._toobusyInfoHover) {
+        return;
+    }
+
+    ctx.save();
+    ctx.font = "11px sans-serif";
+    const pad = 8;
+    const maxTextW = 250;
+    const lineH = 15;
+    const lines = wrapText(ctx, INFO_TEXT, maxTextW);
+    const boxW = maxTextW + pad * 2;
+    const boxH = lines.length * lineH + pad * 2;
+    let bx = cx + r - boxW;            // right-align the box under the badge
+    if (bx < 4) bx = 4;
+    const by = cy + r + 6;            // drop just below the badge into the body
+    ctx.fillStyle = "rgba(20, 26, 32, 0.96)";
+    ctx.strokeStyle = "#2d3642";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    if (ctx.roundRect) {
+        ctx.roundRect(bx, by, boxW, boxH, 6);
+    } else {
+        ctx.rect(bx, by, boxW, boxH);
+    }
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = "#d6dde5";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    lines.forEach((ln, i) => ctx.fillText(ln, bx + pad, by + pad + i * lineH));
+    ctx.restore();
 }
 
 function imageInputConnected(node) {
@@ -215,15 +304,8 @@ app.registerExtension({
         nodeType.prototype.onNodeCreated = function () {
             onNodeCreated?.apply(this, arguments);
 
-            // Transparency: show what this one node folds, so intermediate users
-            // can see inside the "black box" instead of distrusting it.
-            this.addWidget(
-                "text",
-                "folds",
-                "Folds ~10 nodes: UNET+CLIP+VAE +(LoRA) → AuraFlow → Encode×2 → EmptyLatent / VAEEncode(img2img) → KSampler → Decode",
-                () => {},
-                { serialize: false },
-            );
+            // Transparency lives in the top-right "i" badge (hover for what this
+            // node folds) — see drawInfoBadge — instead of an always-on text row.
 
             // Always-visible resolution readout (sits right after the inputs,
             // above the LoRA/advanced buttons).
@@ -285,6 +367,33 @@ app.registerExtension({
             const result = onConnectionsChange?.apply(this, arguments);
             updateResolutionReadout(this);
             return result;
+        };
+
+        // Top-right info badge + hover tooltip.
+        const onDrawForeground = nodeType.prototype.onDrawForeground;
+        nodeType.prototype.onDrawForeground = function (ctx) {
+            onDrawForeground?.apply(this, arguments);
+            try {
+                drawInfoBadge(this, ctx);
+            } catch (err) {
+                // Never let a draw glitch break the node.
+            }
+        };
+
+        const onMouseMove = nodeType.prototype.onMouseMove;
+        nodeType.prototype.onMouseMove = function (event, pos) {
+            const rect = this._toobusyInfoRect;
+            let hover = false;
+            if (rect && Array.isArray(pos)) {
+                const dx = pos[0] - rect.cx;
+                const dy = pos[1] - rect.cy;
+                hover = dx * dx + dy * dy <= (rect.r + 4) * (rect.r + 4);
+            }
+            if (hover !== !!this._toobusyInfoHover) {
+                this._toobusyInfoHover = hover;
+                this.setDirtyCanvas?.(true, true);
+            }
+            return onMouseMove?.apply(this, arguments);
         };
     },
 });

--- a/js/toobusy_z_image_turbo.js
+++ b/js/toobusy_z_image_turbo.js
@@ -40,14 +40,41 @@ function findWidget(node, name) {
     return node.widgets?.find((widget) => widget.name === name);
 }
 
+function imageInputConnected(node) {
+    const input = node.inputs?.find((i) => i.name === "image");
+    return !!(input && input.link != null);
+}
+
 function updateResolutionReadout(node) {
     const readout = findWidget(node, "resolution_readout");
     if (!readout) return;
-    const ratio = String(findWidget(node, "ratio_preset")?.value ?? "1:1");
-    const mp = Number(findWidget(node, "megapixels")?.value ?? 1);
     const div = Number(findWidget(node, "divisible_by")?.value ?? 32);
-    const [w, h] = resolutionFromMegapixels(ratio, mp, div);
-    readout.value = `${ratio} @ ${mp.toFixed(2)}MP -> ${w} x ${h}`;
+    const wv = Number(findWidget(node, "width")?.value ?? 0);
+    const hv = Number(findWidget(node, "height")?.value ?? 0);
+    const manual = wv > 0 && hv > 0;
+
+    let w;
+    let h;
+    let source;
+    if (manual) {
+        w = roundToMultiple(wv, div);
+        h = roundToMultiple(hv, div);
+        source = "manual";
+    } else {
+        const ratio = String(findWidget(node, "ratio_preset")?.value ?? "1:1");
+        const mp = Number(findWidget(node, "megapixels")?.value ?? 1);
+        [w, h] = resolutionFromMegapixels(ratio, mp, div);
+        source = `${ratio} @ ${mp.toFixed(2)}MP`;
+    }
+
+    if (imageInputConnected(node)) {
+        // img2img: a connected image drives the size unless width/height are set.
+        readout.value = manual
+            ? `img2img -> ${w} x ${h} (source scaled)`
+            : `img2img -> source image size`;
+    } else {
+        readout.value = `${source} -> ${w} x ${h}`;
+    }
     node.setDirtyCanvas?.(true, true);
 }
 
@@ -193,7 +220,7 @@ app.registerExtension({
             this.addWidget(
                 "text",
                 "folds",
-                "Folds ~10 nodes: UNET+CLIP+VAE +(LoRA) → AuraFlow → Encode×2 → EmptyLatent → KSampler → Decode",
+                "Folds ~10 nodes: UNET+CLIP+VAE +(LoRA) → AuraFlow → Encode×2 → EmptyLatent / VAEEncode(img2img) → KSampler → Decode",
                 () => {},
                 { serialize: false },
             );
@@ -201,7 +228,7 @@ app.registerExtension({
             // Always-visible resolution readout (sits right after the inputs,
             // above the LoRA/advanced buttons).
             this.addWidget("text", "resolution_readout", "", () => {}, { serialize: false });
-            for (const name of ["ratio_preset", "megapixels", "divisible_by"]) {
+            for (const name of ["ratio_preset", "megapixels", "divisible_by", "width", "height"]) {
                 hookReadout(this, name);
             }
 
@@ -250,6 +277,14 @@ app.registerExtension({
             onConfigure?.apply(this, arguments);
             applyAdvanced(this);
             updateResolutionReadout(this);
+        };
+
+        // Connecting/disconnecting the image input flips the t2i/img2img readout.
+        const onConnectionsChange = nodeType.prototype.onConnectionsChange;
+        nodeType.prototype.onConnectionsChange = function () {
+            const result = onConnectionsChange?.apply(this, arguments);
+            updateResolutionReadout(this);
+            return result;
         };
     },
 });

--- a/tests/test_zimage_resolution_i2i.py
+++ b/tests/test_zimage_resolution_i2i.py
@@ -1,0 +1,170 @@
+"""Regression tests for toobusy Z-Image Turbo resolution + img2img inputs.
+
+Covers the optional ``width``/``height`` direct-resolution fields and the
+optional ``image`` input that auto-switches the node to img2img:
+
+  * explicit width/height feed EmptyLatentImage (rounded to divisible_by);
+  * a connected image switches to img2img -> VAEEncode, never EmptyLatentImage;
+  * with no explicit size, img2img output size follows the source image;
+  * with explicit size, the source is ImageScale'd to it.
+
+Standalone- and pytest-runnable, no ComfyUI runtime (see test_model_overrides).
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# (node_type, kwargs) of every _call_node invocation in the last generate().
+_CALLS = []
+
+
+def _install_stubs():
+    folder_paths = types.ModuleType("folder_paths")
+    folder_paths.get_filename_list = lambda kind: []
+    sys.modules["folder_paths"] = folder_paths
+
+    def fake_call_node(node_type, **kwargs):
+        _CALLS.append((node_type, kwargs))
+        return [f"<{node_type}-out>"]
+
+    pkg = types.ModuleType("toobusy")
+    pkg.__path__ = [ROOT]
+    sys.modules["toobusy"] = pkg
+
+    sub = types.ModuleType("toobusy.ltx23_compact_sampler_node")
+    sub.__path__ = [os.path.join(ROOT, "ltx23_compact_sampler_node")]
+    sys.modules["toobusy.ltx23_compact_sampler_node"] = sub
+
+    samp = types.ModuleType("toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler")
+    samp._call_node = fake_call_node
+    samp._sampler_names = lambda: ["res_multistep", "euler"]
+    samp._default_sampler_name = lambda names: names[0]
+    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
+
+
+def _load(modname, relpath):
+    path = os.path.join(ROOT, relpath)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_stubs()
+_zit = _load(
+    "toobusy.z_image_turbo_node.z_image_turbo",
+    os.path.join("z_image_turbo_node", "z_image_turbo.py"),
+)
+
+
+class _FakeImage:
+    """Stand-in for a ComfyUI IMAGE tensor: shape [batch, height, width, ch]."""
+
+    def __init__(self, height, width, batch=1, channels=3):
+        self.shape = (batch, height, width, channels)
+
+
+def _generate(**overrides):
+    _CALLS.clear()
+    kwargs = dict(
+        model_name="m", clip_name="c", vae_name="v", positive="p", negative="n",
+        ratio_preset="1:1", megapixels=1.0, divisible_by=32, batch_size=1, seed=1,
+        steps=8, cfg=1.0, sampler_name="res_multistep", scheduler="simple",
+        denoise=1.0, aura_shift=3.0, lora_slots=0,
+    )
+    kwargs.update(overrides)
+    return _zit.ToobusyZImageTurbo().generate(**kwargs)
+
+
+def _called(node_type):
+    return [kw for nt, kw in _CALLS if nt == node_type]
+
+
+# --- INPUT_TYPES exposure --------------------------------------------------
+
+def test_exposes_image_width_height_inputs():
+    optional = _zit.ToobusyZImageTurbo.INPUT_TYPES()["optional"]
+    assert optional.get("image") == ("IMAGE",) or optional["image"][0] == "IMAGE"
+    assert optional["width"][0] == "INT"
+    assert optional["height"][0] == "INT"
+
+
+# --- text-to-image (no image) ---------------------------------------------
+
+def test_t2i_default_uses_empty_latent_from_ratio():
+    _, _, w, h = _generate()
+    assert _called("EmptyLatentImage"), "t2i should build an EmptyLatentImage"
+    assert not _called("VAEEncode"), "t2i must not VAE-encode"
+    # 1:1 @ 1.0MP -> sqrt(1e6)=1000 -> round(1000/32)*32 = 992.
+    assert (w, h) == (992, 992)
+
+
+def test_t2i_explicit_width_height_override_ratio():
+    _, _, w, h = _generate(width=768, height=1280)
+    empties = _called("EmptyLatentImage")
+    assert empties and empties[0]["width"] == 768 and empties[0]["height"] == 1280
+    assert (w, h) == (768, 1280)
+
+
+def test_t2i_explicit_size_is_rounded_to_divisible_by():
+    # 700 -> nearest multiple of 32 = 704; 1290 -> 1280.
+    _, _, w, h = _generate(width=700, height=1290, divisible_by=32)
+    assert (w, h) == (704, 1280)
+
+
+def test_t2i_single_dimension_falls_back_to_ratio():
+    # Only width set (height 0) is not a complete manual size -> ratio path.
+    _, _, w, h = _generate(width=512, height=0)
+    assert (w, h) == (992, 992)
+
+
+# --- img2img (image connected) --------------------------------------------
+
+def test_i2i_image_switches_to_vae_encode():
+    img = _FakeImage(height=512, width=768)
+    _generate(image=img)
+    assert _called("VAEEncode"), "img2img should VAE-encode the source"
+    assert not _called("EmptyLatentImage"), "img2img must not build an empty latent"
+
+
+def test_i2i_native_size_follows_source_image():
+    img = _FakeImage(height=512, width=768)
+    _, _, w, h = _generate(image=img)
+    # source 768x512 already multiples of 8 -> reported as-is
+    assert (w, h) == (768, 512)
+
+
+def test_i2i_native_size_cropped_to_multiple_of_8():
+    img = _FakeImage(height=510, width=770)  # not multiples of 8
+    _, _, w, h = _generate(image=img)
+    assert (w, h) == (768, 504)  # 770//8*8=768, 510//8*8=504
+
+
+def test_i2i_explicit_size_scales_source():
+    img = _FakeImage(height=512, width=768)
+    _, _, w, h = _generate(image=img, width=1024, height=1024)
+    scales = _called("ImageScale")
+    assert scales and scales[0]["width"] == 1024 and scales[0]["height"] == 1024
+    assert _called("VAEEncode")
+    assert (w, h) == (1024, 1024)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    if failures:
+        print(f"\n{failures} test(s) failed")
+        sys.exit(1)
+    print("\nall tests passed")

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -87,6 +87,17 @@ def _round_to(value, divisible_by):
     return max(int(divisible_by), int(round(value / divisible_by)) * int(divisible_by))
 
 
+def _image_dims(image):
+    """Pixel (width, height) of a ComfyUI IMAGE tensor, cropped to the VAE's
+    factor of 8. IMAGE tensors are shaped [batch, height, width, channels]."""
+    try:
+        height = int(image.shape[1])
+        width = int(image.shape[2])
+    except (AttributeError, IndexError, TypeError):
+        return 0, 0
+    return (width // 8) * 8, (height // 8) * 8
+
+
 def _resolution_from_megapixels(ratio_preset, megapixels, divisible_by):
     ratio_w, ratio_h = RATIO_PRESETS.get(ratio_preset, RATIO_PRESETS["1:1"])
     pixels = max(0.01, float(megapixels)) * 1_000_000
@@ -102,6 +113,10 @@ class ToobusyZImageTurbo:
     Replaces, in order: UNETLoader + CLIPLoader + VAELoader + (optional
     LoraLoader chain) + ModelSamplingAuraFlow + CLIPTextEncode x2 +
     EmptyLatentImage + KSampler + VAEDecode (~10 nodes -> 1).
+    Connecting the optional `image` input auto-switches to img2img: the image
+    is VAE-encoded as the starting latent (EmptyLatentImage -> VAEEncode, with
+    an optional ImageScale when width/height are set) and `denoise` controls
+    the change strength.
     Needs Z-Image Turbo model + lumina2 text encoder + VAE in your model folders.
     """
 
@@ -143,6 +158,20 @@ class ToobusyZImageTurbo:
                 "lora_slots": ("INT", {"default": 1, "min": 0, "max": MAX_LORA_SLOTS}),
             },
             "optional": {
+                "image": (
+                    "IMAGE",
+                    {"tooltip": "Connect an image to switch this node to img2img. The image is VAE-encoded as the starting latent and 'denoise' becomes the change strength (lower = closer to the source). Leave unconnected for plain text-to-image."},
+                ),
+                "width": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 8192, "step": 8,
+                     "tooltip": "0 = use ratio_preset + megapixels. Set width AND height > 0 to enter the resolution directly (rounded to divisible_by). In img2img this scales the source image to the given size."},
+                ),
+                "height": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 8192, "step": 8,
+                     "tooltip": "0 = use ratio_preset + megapixels. Set width AND height > 0 to enter the resolution directly (rounded to divisible_by). In img2img this scales the source image to the given size."},
+                ),
                 "model_override": ("MODEL",),
                 "clip_override": ("CLIP",),
                 "vae_override": ("VAE",),
@@ -187,12 +216,21 @@ class ToobusyZImageTurbo:
         denoise,
         aura_shift,
         lora_slots,
+        image=None,
+        width=0,
+        height=0,
         model_override=None,
         clip_override=None,
         vae_override=None,
         **lora_kwargs,
     ):
-        width, height = _resolution_from_megapixels(ratio_preset, megapixels, divisible_by)
+        # Resolution: explicit width AND height win (rounded to divisible_by);
+        # otherwise derive from ratio_preset + megapixels.
+        if int(width) > 0 and int(height) > 0:
+            target_w = _round_to(int(width), divisible_by)
+            target_h = _round_to(int(height), divisible_by)
+        else:
+            target_w, target_h = _resolution_from_megapixels(ratio_preset, megapixels, divisible_by)
 
         if model_override is not None:
             print("[toobusy Z-Image Turbo] Using external MODEL override. Internal model loader ignored.")
@@ -233,12 +271,36 @@ class ToobusyZImageTurbo:
         model = _call_node("ModelSamplingAuraFlow", model=model, shift=aura_shift)[0]
         positive_cond = _call_node("CLIPTextEncode", clip=clip, text=positive)[0]
         negative_cond = _call_node("CLIPTextEncode", clip=clip, text=negative)[0]
-        latent_image = _call_node(
-            "EmptyLatentImage",
-            width=width,
-            height=height,
-            batch_size=batch_size,
-        )[0]
+
+        # Latent source. A connected image auto-switches the node to img2img:
+        # the image is VAE-encoded into the starting latent and 'denoise' acts
+        # as the change strength. Otherwise we start from an empty latent (t2i).
+        if image is not None:
+            explicit_size = int(width) > 0 and int(height) > 0
+            if explicit_size:
+                print(f"[toobusy Z-Image Turbo] Image input detected -> img2img. Scaling source to {target_w}x{target_h} (denoise = strength).")
+                pixels = _call_node(
+                    "ImageScale",
+                    image=image,
+                    upscale_method="lanczos",
+                    width=target_w,
+                    height=target_h,
+                    crop="center",
+                )[0]
+                width, height = target_w, target_h
+            else:
+                print("[toobusy Z-Image Turbo] Image input detected -> img2img. Using source image size (denoise = strength).")
+                pixels = image
+                width, height = _image_dims(image)
+            latent_image = _call_node("VAEEncode", pixels=pixels, vae=vae)[0]
+        else:
+            latent_image = _call_node(
+                "EmptyLatentImage",
+                width=target_w,
+                height=target_h,
+                batch_size=batch_size,
+            )[0]
+            width, height = target_w, target_h
 
         sampled = _call_node(
             "KSampler",


### PR DESCRIPTION
## 요약
운영자 요청으로 `toobusy Z-Image Turbo` 노드에 두 기능을 추가합니다.

1. **직접 해상도 입력** — 선택형 `width`/`height` 칸. 둘 다 `> 0`이면 `ratio_preset`+`megapixels` 대신 그 값을 직접 사용(`divisible_by`로 반올림). 한쪽만 채우면 기존 비율 계산으로 폴백.
2. **img2img 자동 전환** — 선택형 `image`(IMAGE) 소켓. 연결되면 자동으로 i2i로 전환되어 `EmptyLatentImage` 대신 `VAEEncode`로 시작 latent을 만들고 `denoise`가 변환 강도가 됩니다.
   - `width`/`height` 지정 시: 소스를 그 크기로 `ImageScale`(center crop).
   - 미지정 시: 소스 이미지 크기를 그대로 사용(VAE 8배수로 crop).
   - 소켓을 비우면 기존 t2i 그대로.

## UI
- 해상도 미리보기 위젯이 `manual -> W x H` / `img2img -> ...` 상태를 표시하고, 이미지 소켓 연결/해제 시(`onConnectionsChange`) 갱신됩니다.

## 테스트
- `tests/test_zimage_resolution_i2i.py` 신규 9케이스(해상도 직접입력/반올림/폴백, i2i 전환·VAEEncode·소스크기·스케일). 로컬 통과.
- 기존 override 테스트 회귀 통과. CI는 이제 `tests/test_*.py`를 자동 검출해 실행.

## 설계 노트 / 확인 부탁
- i2i의 실제 latent·denoise 결과는 ComfyUI 런타임에서 봐야 정확합니다(테스트는 노드 그래프 호출만 검증). **머지 전 실제 노드에서 이미지 물려 한 번 돌려봐 주세요.**
- `ImageScale crop=center` 정책은 취향에 따라 `disabled`(stretch)로 바꿀 수 있습니다.

## 릴리스
버전 bump / 태그 / Registry **없음** — CHANGELOG `[Unreleased]` 기록만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)