### PR TITLE
Z-Image Turbo: fix vanished readout + gate override sockets to Advanced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   (`model_name`/`clip_name`/`vae_name`)을 **기본 노출**해 초보자가 어떤 모델이 물렸는지
   바로 확인할 수 있게 했고(Advanced에 숨기지 않음), Advanced에는 expert 튜닝
   (`divisible_by`/`cfg`/`sampler_name`/`scheduler`/`denoise`/`aura_shift`)과 LoRA만 남겼습니다.
+- 모델 **override 입력 소켓**(`model_override`/`clip_override`/`vae_override`)을 Advanced에서만
+  노출하도록 바꿨습니다. 초보자에겐 불필요한 고급 입력이라 Basic에서는 숨기되, 이미 연결된
+  소켓은 절대 제거하지 않아 기존 그래프가 깨지지 않습니다. `image`(img2img) 입력은 그대로 노출.
 - 항상 떠 있던 2줄 `folds` 설명 텍스트를 **노드 우상단 `i` info 배지 + 호버 툴팁**으로
   교체했습니다(노드 화면을 덜 어지럽게). 툴팁은 노드 본문을 가리지 않도록 노드 **오른쪽
   바깥**에 표시됩니다.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ LoRA 동작:
 Basic / Advanced:
 
 - 기본은 **Basic 화면**으로, 자주 쓰는 입력이 보입니다: **`model_name`/`clip_name`/`vae_name`(모델 로드 슬롯)**, `positive`, `negative`, `ratio_preset`, `megapixels`, `width`, `height`, `batch_size`, `seed`, `steps`. 모델 로드 슬롯을 기본 노출해, 어떤 모델이 물려 있는지 바로 보고 고칠 수 있습니다(엉뚱한 모델로 헤매는 상황 방지).
-- `Show advanced settings` 버튼을 누르면 expert 튜닝 컨트롤(`divisible_by`, `cfg`, `sampler_name`, `scheduler`, `denoise`, `aura_shift`)과 LoRA 슬롯/버튼이 나타납니다. 상태는 노드에 저장되어 그래프를 다시 열어도 유지됩니다.
+- `Show advanced settings` 버튼을 누르면 expert 튜닝 컨트롤(`divisible_by`, `cfg`, `sampler_name`, `scheduler`, `denoise`, `aura_shift`)과 LoRA 슬롯/버튼, 그리고 **모델 override 입력 소켓**(`model_override`/`clip_override`/`vae_override`)이 나타납니다. override 소켓은 고급 입력이라 Basic에서는 숨겨지며(이미 연결돼 있으면 유지), `image`(img2img) 입력은 항상 노출됩니다. 상태는 노드에 저장되어 그래프를 다시 열어도 유지됩니다.
 - **info 배지**: 노드 우상단 모서리의 `i` 아이콘에 마우스를 올리면, 이 노드가 어떤 노드들을 접는지(t2i/img2img 흐름 포함) 설명 툴팁이 뜹니다.
 - **해상도 미리보기**: `ratio_preset @ megapixels -> 가로 x 세로`(직접 입력 시 `manual -> ...`, 이미지 연결 시 `img2img -> ...`) 표시 위젯이 항상 보여, 큐에 올리기 전에 실제 생성 크기를 확인할 수 있습니다.
 

--- a/js/toobusy_z_image_turbo.js
+++ b/js/toobusy_z_image_turbo.js
@@ -54,6 +54,55 @@ function findWidget(node, name) {
     return node.widgets?.find((widget) => widget.name === name);
 }
 
+// Read-only resolution status line. Drawn directly on the canvas (custom widget
+// type) so a click never opens an edit box — a plain "text" widget pops a
+// prompt, and a customtext DOM widget collapsed to zero height. Always reserves
+// its row, coloured with the shared accent.
+function makeReadoutWidget() {
+    return {
+        type: "toobusy_readout",
+        name: "resolution_readout",
+        value: "",
+        options: { serialize: false },
+        serialize: false,
+        draw(ctx, node, widgetWidth, widgetY, height) {
+            ctx.save();
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.font = "600 12px sans-serif";
+            ctx.fillStyle = ACCENT;
+            ctx.fillText(String(this.value || ""), widgetWidth * 0.5, widgetY + height * 0.5);
+            ctx.restore();
+        },
+        computeSize(width) {
+            return [width || 0, 22];
+        },
+    };
+}
+
+// The model/clip/vae override sockets are an advanced surface: beginners pick a
+// model via the model_name/clip_name/vae_name dropdowns and never need these.
+// Show them only in Advanced. The `image` (img2img) input is NOT gated.
+const OVERRIDE_INPUT_SPECS = [
+    ["model_override", "MODEL"],
+    ["clip_override", "CLIP"],
+    ["vae_override", "VAE"],
+];
+
+function setOverrideInputsVisible(node, visible) {
+    for (const [name, type] of OVERRIDE_INPUT_SPECS) {
+        const idx = node.inputs ? node.inputs.findIndex((i) => i.name === name) : -1;
+        const exists = idx >= 0;
+        if (visible) {
+            if (!exists) node.addInput(name, type);
+        } else if (exists && node.inputs[idx].link == null) {
+            // Never drop a wired override — only hide the unused ones, so toggling
+            // back to Basic can't silently break a connected graph.
+            node.removeInput(idx);
+        }
+    }
+}
+
 function titleHeight() {
     return (typeof LiteGraph !== "undefined" && LiteGraph.NODE_TITLE_HEIGHT) || 30;
 }
@@ -325,6 +374,8 @@ function applyAdvanced(node) {
     for (const name of ADVANCED_WIDGETS) {
         setWidgetVisible(node, findWidget(node, name), advanced);
     }
+    // Override sockets (MODEL/CLIP/VAE) are advanced-only; image input stays.
+    setOverrideInputsVisible(node, advanced);
     if (node._toobusyAdvButton) {
         node._toobusyAdvButton.name = advanced ? "Hide advanced settings" : "Show advanced settings";
     }
@@ -348,27 +399,12 @@ app.registerExtension({
 
             // Always-visible resolution readout (sits right after the inputs,
             // above the LoRA/advanced buttons).
-            // Read-only resolution status line. Uses a customtext (DOM) widget
-            // with readOnly so clicking it does nothing — a plain "text" widget
-            // pops an edit prompt, which felt unfinished. Coloured to stand out
-            // as a status readout rather than an input.
-            const readout = this.addWidget("customtext", "resolution_readout", "", () => {}, { serialize: false });
-            if (readout.inputEl) {
-                const el = readout.inputEl;
-                el.readOnly = true;
-                el.style.fontSize = "12px";
-                el.style.fontWeight = "600";
-                el.style.color = ACCENT;
-                el.style.textAlign = "center";
-                el.style.background = "transparent";
-                el.style.border = "none";
-                el.style.boxShadow = "none";
-                el.style.resize = "none";
-                el.style.overflow = "hidden";
-                el.style.cursor = "default";
-                el.style.minHeight = "0px";
-                el.style.height = "20px";
-                el.rows = 1;
+            // Read-only resolution status line (canvas-drawn, not editable).
+            const readout = makeReadoutWidget();
+            if (this.addCustomWidget) {
+                this.addCustomWidget(readout);
+            } else {
+                (this.widgets = this.widgets || []).push(readout);
             }
             for (const name of ["ratio_preset", "megapixels", "divisible_by", "width", "height"]) {
                 hookReadout(this, name);


### PR DESCRIPTION
운영자 피드백 2건 수정 (PR #36 후속).

1. **readout 사라짐 회귀 수정** — `customtext`(DOM) 위젯이 높이 0으로 접혀 사라졌던 문제. **캔버스에 직접 그리는 커스텀 위젯**으로 교체 → 항상 행을 차지하고, accent 색으로 렌더, 비표준 위젯 타입이라 클릭해도 편집 프롬프트가 안 뜸.
2. **모델 override 소켓을 Advanced 전용으로** — `model_override`/`clip_override`/`vae_override` 입력 소켓을 Basic에서 숨기고 `Show advanced settings`일 때만 노출. 초보자는 model_name/clip_name/vae_name 드롭다운으로 모델 선택하니 override는 불필요. **이미 연결된 소켓은 제거하지 않아** 토글로 그래프가 깨지지 않음. `image`(img2img) 소켓은 항상 노출.

⚠️ 인앱 확인: readout이 다시 보이고 클릭 안 되는지 / Basic에선 override 3소켓 숨고 Advanced 켜면 나타나는지 / 연결된 상태에서 토글해도 링크 유지되는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)