### PR TITLE
docs: use official model filenames in z_image_turbo example

### DIFF
--- a/docs/workflows/z_image_turbo.json
+++ b/docs/workflows/z_image_turbo.json
@@ -99,9 +99,9 @@
         "toobusy_advanced": true
       },
       "widgets_values": [
-        "ZIT\\zImage_turbo.safetensors",
-        "ZIT\\zImage_textEncoder.safetensors",
-        "FLUX1\\ae.safetensors",
+        "z_image_turbo_bf16.safetensors",
+        "qwen_3_4b.safetensors",
+        "ae.safetensors",
         "blue sky,huge clouds is shape of text \"Z Image Turbo\"",
         "",
         "16:9",


### PR DESCRIPTION
예제 워크플로우(`docs/workflows/z_image_turbo.json`)의 모델 위젯값이 운영자 로컬 파일명이라, 다른 사람이 열면 missing으로 떴습니다. 워크플로우 안 Note 노드가 링크하는 **공식 Comfy-Org 파일명**으로 맞췄습니다:

- `model_name` → `z_image_turbo_bf16.safetensors`
- `clip_name` → `qwen_3_4b.safetensors`
- `vae_name` → `ae.safetensors`

JSON만 변경. 릴리스: 버전/태그/Registry 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
