### PR TITLE
docs: README two buckets (Setup removed in 0.2.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 </p>
 <p align="center"><sub>▶ 리뷰·소개 영상 (클릭하면 YouTube) · 너무바쁜베짱이</sub></p>
 
-노드는 세 갈래로 접혀 있습니다:
+노드는 두 갈래로 접혀 있습니다:
 
 - **`toobusy/Plan`** — 기획·연출·프롬프트를 접는다: Keyframe Maker, Storyboard Board, Ideogram Layout Builder, Ideogram Prompt Polish
 - **`toobusy/Make`** — 생성 파이프라인을 접는다: Z-Image Turbo, Ideogram4 T2I, LTX2.3 3종


### PR DESCRIPTION
Coda 검수 지적 반영: Setup 버킷이 0.2.8에서 HF 로더와 함께 제거됐는데 README 소개가 여전히 '세 갈래'(Plan/Make/Setup)였음 → '두 갈래'(Plan/Make)로 수정. 0.2.8 태그 전에 main 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)