### PR TITLE
Promote SCAIL replacement_mode to Basic + mask convention mismatch warning

### DIFF
--- a/js/toobusy_wan_scail_extend_sampler.js
+++ b/js/toobusy_wan_scail_extend_sampler.js
@@ -4,14 +4,15 @@ const MAX_EXTEND_SEGMENTS = 8;
 
 // Expert tuning hidden by default (Basic view). The extend segment controls
 // are NOT here — growing the video is the whole point of this node, so the
-// +/- segment surface always shows.
+// +/- segment surface always shows. replacement_mode is deliberately NOT here
+// either: animation vs replacement changes what the node fundamentally does
+// (whose scene, whose character), so it stays on the Basic surface.
 const ADVANCED_WIDGETS = [
     "sampler_name",
     "scheduler",
     "shift",
     "previous_frame_count",
     "color_match",
-    "replacement_mode",
     "pose_strength",
     "pose_start",
     "pose_end",
@@ -255,7 +256,8 @@ function updateFramesReadout(node) {
     const total = parts.reduce((sum, value) => sum + value, 0);
     const seconds = (total / 16).toFixed(1);
     const sum = parts.length > 1 ? `${parts.join(" + ")} = ` : "";
-    readout.value = `${sum}${total} frames · ~${seconds}s @ 16fps`;
+    const mode = findWidget(node, "replacement_mode")?.value ? "Replacement" : "Animation";
+    readout.value = `${sum}${total} frames · ~${seconds}s @ 16fps · ${mode}`;
     node.setDirtyCanvas?.(true, true);
 }
 
@@ -348,6 +350,7 @@ app.registerExtension({
             }
             hookReadout(this, "base_frames");
             hookReadout(this, "previous_frame_count");
+            hookReadout(this, "replacement_mode");
             for (let slot = 1; slot <= MAX_EXTEND_SEGMENTS; slot += 1) {
                 hookReadout(this, `extend_${slot}_frames`);
             }

--- a/tests/test_wan_scail_extend_sampler.py
+++ b/tests/test_wan_scail_extend_sampler.py
@@ -249,6 +249,27 @@ def test_old_core_without_scail2_inputs_fails_clearly():
         raise AssertionError("expected RuntimeError on old core")
 
 
+# --- mask background estimation (torch only) ---------------------------------
+
+def test_mask_background_estimation():
+    if not _HAS_TORCH:
+        print("SKIP test_mask_background_estimation (no torch)")
+        return
+    import torch
+
+    white = torch.ones(2, 64, 64, 3)
+    black = torch.zeros(2, 64, 64, 3)
+    gray = torch.full((1, 64, 64, 3), 0.5)
+    assert _mod._estimate_mask_background(white) == "white"
+    assert _mod._estimate_mask_background(black) == "black"
+    assert _mod._estimate_mask_background(gray) is None
+    # A character in the middle must not flip the corner-based estimate.
+    busy = torch.zeros(1, 64, 64, 3)
+    busy[0, 16:48, 16:48, 2] = 1.0
+    assert _mod._estimate_mask_background(busy) == "black"
+    assert _mod._estimate_mask_background(None) is None
+
+
 # --- color transfer (torch only) ---------------------------------------------
 
 def test_color_match_identity_when_stats_match():

--- a/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
+++ b/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
@@ -127,6 +127,33 @@ def _scail_missing_params():
     return [name for name in _SCAIL_REQUIRED_PARAMS if name not in params]
 
 
+def _estimate_mask_background(mask_video):
+    """'white' / 'black' from the corner luminance of the first mask frame, or
+    None when ambiguous. SCAIL-2's mode convention lives in the mask background
+    (animation = black, replacement = white), so a mismatch here almost always
+    means the replacement_mode toggles on this node and on 'Create SCAIL-2
+    Colored Mask' disagree."""
+    try:
+        frame = mask_video[0]
+        height = int(frame.shape[0])
+        width = int(frame.shape[1])
+        patch = max(1, min(8, height // 8, width // 8))
+        corners = (
+            frame[:patch, :patch],
+            frame[:patch, width - patch:],
+            frame[height - patch:, :patch],
+            frame[height - patch:, width - patch:],
+        )
+        luminance = sum(float(corner.mean()) for corner in corners) / 4.0
+    except Exception:
+        return None
+    if luminance >= 0.75:
+        return "white"
+    if luminance <= 0.25:
+        return "black"
+    return None
+
+
 def _chunk_plan(base_frames, extend_segments, segment_frames, seed):
     """[(length, noise_seed), ...] for the base chunk plus each active extend
     segment. Chunk seeds step from the base seed so each chunk gets fresh
@@ -383,6 +410,18 @@ class ToobusyWanSCAILExtendSampler:
                 raise ValueError(
                     f"extend_{index + 1}_frames ({segment_frames[index]}) must be larger than "
                     f"previous_frame_count ({overlap}); the chunk would only re-render the overlap."
+                )
+
+        if pose_video_mask is not None:
+            estimated = _estimate_mask_background(pose_video_mask)
+            expected = "white" if replacement_mode else "black"
+            if estimated is not None and estimated != expected:
+                mode_name = "replacement" if replacement_mode else "animation"
+                print(
+                    f"[toobusy Wan SCAIL] Warning: pose_video_mask background looks {estimated} "
+                    f"but {mode_name} mode expects {expected}. Set replacement_mode to the SAME "
+                    "value on this node and on 'Create SCAIL-2 Colored Mask' — mismatched mask "
+                    "conventions degrade quality, especially with multiple people."
                 )
 
         plan = _chunk_plan(base_frames, extend_segments, segment_frames, seed)


### PR DESCRIPTION
Operator feedback: animation vs replacement changes what the node
fundamentally does (whose scene, whose character), so hiding the
toggle in Advanced left users running a mode they could not see.

- replacement_mode now always visible (removed from Advanced gating).
- The frames readout appends the active mode (... 217 frames ·
  ~13.6s @ 16fps · Animation).
- generate() estimates the pose_video_mask background from its corner
  luminance and prints a clear warning when it does not match the
  mode convention (animation = black, replacement = white) - the
  exact silent mismatch the operator hit with the Colored Mask node
  set to replacement while the sampler ran animation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
