### PR TITLE
Fix V3 node calls: fill schema defaults in _call_node/_call_core

### DIFF
--- a/ltx23_compact_sampler_node/ltx23_compact_sampler.py
+++ b/ltx23_compact_sampler_node/ltx23_compact_sampler.py
@@ -13,6 +13,39 @@ def _node_class(class_name):
         ) from exc
 
 
+def _fill_input_defaults(cls, kwargs, params, has_var_keyword):
+    """Add INPUT_TYPES defaults for declared inputs the caller didn't pass.
+
+    The graph executor does this from the node schema before calling a node;
+    when we call a node class directly we must do the same, otherwise a core
+    update that adds a new widget (e.g. ImageScaleToTotalPixels growing a
+    required `resolution_steps`) breaks every fold that calls it. V3 nodes
+    are the sharp edge: their `execute` has no Python defaults for schema
+    inputs, so a missing kwarg is a hard TypeError.
+    """
+    try:
+        spec = cls.INPUT_TYPES()
+    except Exception:
+        return kwargs
+    if not isinstance(spec, dict):
+        return kwargs
+    for section in ("required", "optional"):
+        for name, definition in (spec.get(section) or {}).items():
+            if name in kwargs:
+                continue
+            if not has_var_keyword and params is not None and name not in params:
+                continue
+            if not isinstance(definition, (list, tuple)) or not definition:
+                continue
+            options = definition[1] if len(definition) > 1 else None
+            if isinstance(options, dict) and "default" in options:
+                kwargs[name] = options["default"]
+            elif isinstance(definition[0], (list, tuple)) and definition[0]:
+                # Combo without an explicit default: first entry, like the UI.
+                kwargs[name] = definition[0][0]
+    return kwargs
+
+
 def _call_node(class_name, **kwargs):
     cls = _node_class(class_name)
     node = cls()
@@ -22,10 +55,27 @@ def _call_node(class_name, **kwargs):
 
     fn = getattr(node, fn_name)
     signature = inspect.signature(fn)
-    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+    has_var_keyword = any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()
+    )
+
+    # V3 io.ComfyNode classes expose FUNCTION as a *args/**kwargs normalizer;
+    # the real parameter list lives on `execute`.
+    params = None if has_var_keyword else signature.parameters
+    if has_var_keyword and hasattr(cls, "execute"):
+        try:
+            execute_params = inspect.signature(cls.execute).parameters
+            if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in execute_params.values()):
+                params = execute_params
+                has_var_keyword = False
+        except (TypeError, ValueError):
+            pass
+
+    kwargs = _fill_input_defaults(cls, dict(kwargs), params, has_var_keyword)
+    if has_var_keyword or params is None:
         return fn(**kwargs)
 
-    filtered = {key: value for key, value in kwargs.items() if key in signature.parameters}
+    filtered = {key: value for key, value in kwargs.items() if key in params}
     return fn(**filtered)
 
 

--- a/tests/test_call_node_helper.py
+++ b/tests/test_call_node_helper.py
@@ -1,0 +1,149 @@
+"""Regression tests for the shared `_call_node` helper (ltx23 module).
+
+The operator hit this in the field: a core update gave ImageScaleToTotalPixels
+a new required `resolution_steps` input, and calling the V3 node class
+directly raised TypeError because V3 `execute` methods carry no Python
+defaults — the graph executor fills them from the node schema. `_call_node`
+must do the same: fill INPUT_TYPES defaults for missing inputs, resolve the
+real signature behind the V3 *args/**kwargs normalizer, and still filter
+unknown kwargs.
+
+Standalone- and pytest-runnable, no ComfyUI runtime.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+_NODE_REGISTRY = {}
+
+
+def _install_stubs():
+    nodes_mod = types.ModuleType("nodes")
+    nodes_mod.NODE_CLASS_MAPPINGS = _NODE_REGISTRY
+    sys.modules["nodes"] = nodes_mod
+
+
+def _load(modname, relpath):
+    path = os.path.join(ROOT, relpath)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_stubs()
+_mod = _load(
+    "toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler",
+    os.path.join("ltx23_compact_sampler_node", "ltx23_compact_sampler.py"),
+)
+
+
+class _ClassicNode:
+    """V1-style node: FUNCTION names a plain method with Python defaults."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "method": (["lanczos", "bilinear"],),
+                "new_widget": ("INT", {"default": 7}),
+            },
+        }
+
+    FUNCTION = "run"
+
+    def run(self, image, method, new_widget=0):
+        return (image, method, new_widget)
+
+
+class _V3Node:
+    """V3-style node: FUNCTION resolves to a *args/**kwargs normalizer and
+    `execute` has required params whose defaults only exist in the schema —
+    the exact shape that broke ImageScaleToTotalPixels."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "upscale_method": (["lanczos", "bilinear"],),
+                "megapixels": ("FLOAT", {"default": 1.0}),
+                "resolution_steps": ("INT", {"default": 8}),
+            },
+        }
+
+    FUNCTION = "EXECUTE_NORMALIZED"
+
+    @classmethod
+    def EXECUTE_NORMALIZED(cls, *args, **kwargs):
+        return cls.execute(*args, **kwargs)
+
+    @classmethod
+    def execute(cls, image, upscale_method, megapixels, resolution_steps):
+        return (image, upscale_method, megapixels, resolution_steps)
+
+
+def test_classic_node_gets_schema_default_for_missing_widget():
+    _NODE_REGISTRY["Classic"] = _ClassicNode
+    image, method, new_widget = _mod._call_node("Classic", image="img", method="lanczos")
+    assert (image, method, new_widget) == ("img", "lanczos", 7)
+
+
+def test_classic_node_filters_unknown_kwargs():
+    _NODE_REGISTRY["Classic"] = _ClassicNode
+    result = _mod._call_node("Classic", image="img", method="lanczos", bogus=123)
+    assert result[0] == "img"
+
+
+def test_v3_node_missing_required_schema_default_is_filled():
+    _NODE_REGISTRY["V3"] = _V3Node
+    # The field crash: caller predates resolution_steps entirely.
+    image, method, mp, steps = _mod._call_node(
+        "V3", image="img", upscale_method="lanczos", megapixels=1.0
+    )
+    assert steps == 8, "schema default must be filled like the graph executor does"
+
+
+def test_v3_node_combo_without_default_uses_first_option():
+    _NODE_REGISTRY["V3"] = _V3Node
+    _, method, _, _ = _mod._call_node("V3", image="img", megapixels=2.0)
+    assert method == "lanczos"
+
+
+def test_v3_node_explicit_kwargs_win_over_defaults():
+    _NODE_REGISTRY["V3"] = _V3Node
+    *_, steps = _mod._call_node(
+        "V3", image="img", upscale_method="bilinear", megapixels=2.0, resolution_steps=3
+    )
+    assert steps == 3
+
+
+def test_v3_node_unknown_kwargs_filtered():
+    _NODE_REGISTRY["V3"] = _V3Node
+    result = _mod._call_node("V3", image="img", upscale_method="lanczos", megapixels=1.0, bogus=1)
+    assert result[0] == "img"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+            except Exception as exc:  # noqa: BLE001 - regression visibility
+                failures += 1
+                print(f"ERROR {name}: {type(exc).__name__}: {exc}")
+    if failures:
+        print(f"\n{failures} test(s) failed")
+        sys.exit(1)
+    print("\nall tests passed")

--- a/tests/test_wan_scail_extend_sampler.py
+++ b/tests/test_wan_scail_extend_sampler.py
@@ -35,6 +35,7 @@ def _install_stubs():
 
     samp = types.ModuleType("toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler")
     samp._sampler_names = lambda: ["euler", "res_multistep"]
+    samp._fill_input_defaults = lambda cls, kwargs, params, has_var_keyword: kwargs
     sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
 
 

--- a/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
+++ b/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
@@ -20,7 +20,7 @@ time with a clear "update ComfyUI" message.
 
 import inspect
 
-from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _sampler_names
+from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _fill_input_defaults, _sampler_names
 
 MAX_EXTEND_SEGMENTS = 8
 
@@ -104,9 +104,13 @@ def _call_core(class_name, hint="", **kwargs):
     fn = getattr(target, getattr(cls, "FUNCTION", "execute"))
 
     params = _execute_params(cls, fn)
-    if params is not None and not any(
+    has_var_keyword = params is None or any(
         p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-    ):
+    )
+    # Fill schema defaults for inputs we don't pass (the executor does this
+    # in-graph; a core update adding a widget must not break the fold).
+    kwargs = _fill_input_defaults(cls, dict(kwargs), None if has_var_keyword else params, has_var_keyword)
+    if not has_var_keyword:
         kwargs = {key: value for key, value in kwargs.items() if key in params}
 
     result = fn(**kwargs)


### PR DESCRIPTION
Operator field crash: ToobusyZITControlNet -> ImageScaleToTotalPixels
raised 'execute() missing 1 required positional argument:
resolution_steps' on a core where that V3 node grew a new input. V3
execute methods carry no Python defaults - the graph executor fills
them from the node schema, and calling the class directly must do the
same.

_call_node (shared by Z-Image / Hires / ZIT ControlNet / LTX folds)
and the SCAIL _call_core now fill INPUT_TYPES defaults for inputs the
caller does not pass (combo without default = first option, matching
the UI), resolve the real signature behind the V3 *args/**kwargs
normalizer, and still filter unknown kwargs. Covered by
tests/test_call_node_helper.py including the exact field shape.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
