### PR TITLE
Z-Image Turbo: model/clip/vae/conditioning passthrough outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### Changed
+- `toobusy Z-Image Turbo`에 **passthrough 출력 5개 추가**: `model`/`clip`/`vae`
+  (내부 로드 + LoRA/shift 반영 결과) + `positive`/`negative`(인코딩된 컨디셔닝).
+  `toobusy Hires Upscale`(vae)나 2차 샘플러 패스에 외부 로더/CLIPTextEncode 없이
+  바로 연결할 수 있습니다. 기존 출력 슬롯 순서는 유지(뒤에 추가). zit_control
+  패치는 해당 런의 해상도에 묶여 있어 model 출력에 포함되지 않습니다. (운영자 피드백)
 - `toobusy ZIT ControlNet` UI 정리: Basic 표면은 타입별 **스위치 + 스트렝스**만
   남기고, 전처리 토글 3개("이미 만든 컨트롤 맵" 모드)·전처리 해상도·canny
   임계값은 `Show advanced settings` 뒤로 이동했습니다(기본 동작 불변). 우상단

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ## [Unreleased]
 
 ### Changed
-- `toobusy Z-Image Turbo`에 **passthrough 출력 5개 추가**: `model`/`clip`/`vae`
-  (내부 로드 + LoRA/shift 반영 결과) + `positive`/`negative`(인코딩된 컨디셔닝).
-  `toobusy Hires Upscale`(vae)나 2차 샘플러 패스에 외부 로더/CLIPTextEncode 없이
-  바로 연결할 수 있습니다. 기존 출력 슬롯 순서는 유지(뒤에 추가). zit_control
-  패치는 해당 런의 해상도에 묶여 있어 model 출력에 포함되지 않습니다. (운영자 피드백)
+- `toobusy Z-Image Turbo`에 **passthrough 출력 6개 추가**: `model`(LoRA+shift+
+  zit_control까지 — 이 노드가 실제 샘플링한 그 모델), `model_clean`(로드 직후
+  원본 — 2차 패스에서 LoRA를 갈아끼울 때), `clip`/`vae`, `positive`/`negative`
+  (인코딩된 컨디셔닝). `toobusy Hires Upscale`(vae)나 2차 샘플러 패스에 외부
+  로더/CLIPTextEncode 없이 바로 연결됩니다. 기존 출력 슬롯 순서는 유지(뒤에 추가).
+  주의: zit_control 포함 `model`은 컨트롤 맵이 해당 런 해상도에 묶여 있어 다른
+  해상도 2차 패스엔 `model_clean` 권장. (운영자 피드백)
 - `toobusy ZIT ControlNet` UI 정리: Basic 표면은 타입별 **스위치 + 스트렝스**만
   남기고, 전처리 토글 3개("이미 만든 컨트롤 맵" 모드)·전처리 해상도·canny
   임계값은 `Show advanced settings` 뒤로 이동했습니다(기본 동작 불변). 우상단

--- a/README.md
+++ b/README.md
@@ -488,7 +488,8 @@ Load Upscale Model -> Upscale Image (using Model) -> Upscale Image By -> VAE Enc
 되돌리고, 바로 두 번째 샘플러 패스에 꽂을 수 있게 VAE 인코딩까지 끝냅니다.
 
 - 입력: `image` + `vae`, 선택 `upscale_model`(UPSCALE_MODEL override — 연결 시
-  내부 로더 스킵).
+  내부 로더 스킵). `vae`는 `toobusy Z-Image Turbo`의 `vae` passthrough 출력을
+  그대로 받으면 Load VAE 노드가 필요 없습니다.
 - 위젯: `upscale_model_name`(Remacri가 있으면 기본 선택), `downscale_method`
   (기본 lanczos), `scale_by`(1.0이면 리샘플 단계 생략).
 - 출력: `image`(최종 픽셀) / `latent`(VAE 인코딩) / `width` / `height`.

--- a/tests/test_zimage_resolution_i2i.py
+++ b/tests/test_zimage_resolution_i2i.py
@@ -1,4 +1,4 @@
-"""Regression tests for toobusy Z-Image Turbo resolution + img2img inputs.
+﻿"""Regression tests for toobusy Z-Image Turbo resolution + img2img inputs.
 
 Covers the optional ``width``/``height`` direct-resolution fields and the
 optional ``image`` input that auto-switches the node to img2img:
@@ -81,8 +81,34 @@ def _generate(**overrides):
     return _zit.ToobusyZImageTurbo().generate(**kwargs)
 
 
+def _generate_wh(**overrides):
+    """width/height-first view of generate(): the node now appends
+    model/clip/vae/positive/negative passthrough outputs after the original
+    image/latent/width/height slots."""
+    return _generate(**overrides)[2:]
+
+
 def _called(node_type):
     return [kw for nt, kw in _CALLS if nt == node_type]
+
+
+# --- passthrough outputs ----------------------------------------------------
+
+def test_passthrough_outputs_expose_loaded_objects():
+    result = _generate()
+    assert len(result) == 9
+    image, latent, w, h, model, clip, vae, positive, negative = result
+    # LoRA off + shift applied -> model passthrough is the shift-patched model.
+    assert model == "<ModelSamplingAuraFlow-out>"
+    assert clip == "<CLIPLoader-out>"
+    assert vae == "<VAELoader-out>"
+    assert positive == "<CLIPTextEncode-out>" and negative == "<CLIPTextEncode-out>"
+
+
+def test_output_slot_order_is_backward_compatible():
+    types = _zit.ToobusyZImageTurbo.RETURN_TYPES
+    assert types[:4] == ("IMAGE", "LATENT", "INT", "INT"), "existing slots must not move"
+    assert types[4:] == ("MODEL", "CLIP", "VAE", "CONDITIONING", "CONDITIONING")
 
 
 # --- INPUT_TYPES exposure --------------------------------------------------
@@ -103,7 +129,7 @@ def test_no_lora_auto_enabled_by_default():
 # --- text-to-image (no image) ---------------------------------------------
 
 def test_t2i_default_uses_empty_latent_from_ratio():
-    _, _, w, h = _generate()
+    w, h, *_ = _generate_wh()
     assert _called("EmptyLatentImage"), "t2i should build an EmptyLatentImage"
     assert not _called("VAEEncode"), "t2i must not VAE-encode"
     # 1:1 @ 1.0MP -> sqrt(1e6)=1000 -> round(1000/32)*32 = 992.
@@ -111,7 +137,7 @@ def test_t2i_default_uses_empty_latent_from_ratio():
 
 
 def test_t2i_explicit_width_height_override_ratio():
-    _, _, w, h = _generate(width=768, height=1280)
+    w, h, *_ = _generate_wh(width=768, height=1280)
     empties = _called("EmptyLatentImage")
     assert empties and empties[0]["width"] == 768 and empties[0]["height"] == 1280
     assert (w, h) == (768, 1280)
@@ -119,13 +145,13 @@ def test_t2i_explicit_width_height_override_ratio():
 
 def test_t2i_explicit_size_is_rounded_to_divisible_by():
     # 700 -> nearest multiple of 32 = 704; 1290 -> 1280.
-    _, _, w, h = _generate(width=700, height=1290, divisible_by=32)
+    w, h, *_ = _generate_wh(width=700, height=1290, divisible_by=32)
     assert (w, h) == (704, 1280)
 
 
 def test_t2i_single_dimension_falls_back_to_ratio():
     # Only width set (height 0) is not a complete manual size -> ratio path.
-    _, _, w, h = _generate(width=512, height=0)
+    w, h, *_ = _generate_wh(width=512, height=0)
     assert (w, h) == (992, 992)
 
 
@@ -140,20 +166,20 @@ def test_i2i_image_switches_to_vae_encode():
 
 def test_i2i_native_size_follows_source_image():
     img = _FakeImage(height=512, width=768)
-    _, _, w, h = _generate(image=img)
+    w, h, *_ = _generate_wh(image=img)
     # source 768x512 already multiples of 8 -> reported as-is
     assert (w, h) == (768, 512)
 
 
 def test_i2i_native_size_cropped_to_multiple_of_8():
     img = _FakeImage(height=510, width=770)  # not multiples of 8
-    _, _, w, h = _generate(image=img)
+    w, h, *_ = _generate_wh(image=img)
     assert (w, h) == (768, 504)  # 770//8*8=768, 510//8*8=504
 
 
 def test_i2i_explicit_size_scales_source():
     img = _FakeImage(height=512, width=768)
-    _, _, w, h = _generate(image=img, width=1024, height=1024)
+    w, h, *_ = _generate_wh(image=img, width=1024, height=1024)
     scales = _called("ImageScale")
     assert scales and scales[0]["width"] == 1024 and scales[0]["height"] == 1024
     assert _called("VAEEncode")

--- a/tests/test_zimage_resolution_i2i.py
+++ b/tests/test_zimage_resolution_i2i.py
@@ -83,8 +83,8 @@ def _generate(**overrides):
 
 def _generate_wh(**overrides):
     """width/height-first view of generate(): the node now appends
-    model/clip/vae/positive/negative passthrough outputs after the original
-    image/latent/width/height slots."""
+    model/model_clean/clip/vae/positive/negative passthrough outputs after
+    the original image/latent/width/height slots."""
     return _generate(**overrides)[2:]
 
 
@@ -96,10 +96,12 @@ def _called(node_type):
 
 def test_passthrough_outputs_expose_loaded_objects():
     result = _generate()
-    assert len(result) == 9
-    image, latent, w, h, model, clip, vae, positive, negative = result
-    # LoRA off + shift applied -> model passthrough is the shift-patched model.
+    assert len(result) == 10
+    image, latent, w, h, model, model_clean, clip, vae, positive, negative = result
+    # `model` is the final sampled model (shift applied here; no LoRA/controlnet
+    # in this run); `model_clean` is the as-loaded model before any patching.
     assert model == "<ModelSamplingAuraFlow-out>"
+    assert model_clean == "<UNETLoader-out>"
     assert clip == "<CLIPLoader-out>"
     assert vae == "<VAELoader-out>"
     assert positive == "<CLIPTextEncode-out>" and negative == "<CLIPTextEncode-out>"
@@ -108,7 +110,9 @@ def test_passthrough_outputs_expose_loaded_objects():
 def test_output_slot_order_is_backward_compatible():
     types = _zit.ToobusyZImageTurbo.RETURN_TYPES
     assert types[:4] == ("IMAGE", "LATENT", "INT", "INT"), "existing slots must not move"
-    assert types[4:] == ("MODEL", "CLIP", "VAE", "CONDITIONING", "CONDITIONING")
+    assert types[4:] == ("MODEL", "MODEL", "CLIP", "VAE", "CONDITIONING", "CONDITIONING")
+    names = _zit.ToobusyZImageTurbo.RETURN_NAMES
+    assert names[4:6] == ("model", "model_clean")
 
 
 # --- INPUT_TYPES exposure --------------------------------------------------

--- a/tests/test_zit_controlnet.py
+++ b/tests/test_zit_controlnet.py
@@ -175,7 +175,11 @@ def test_zimage_applies_one_patch_per_entry_at_generation_size():
             {"type": "pose", "image": "map-C", "strength": 1.0},
         ],
     }
-    _generate(zit_control=control, width=768, height=1280)
+    result = _generate(zit_control=control, width=768, height=1280)
+    # Passthrough flavors: `model` carries the controlnet patches, `model_clean`
+    # is the as-loaded model (slots 4 and 5).
+    assert result[4] == "<QwenImageDiffsynthControlnet-out>"
+    assert result[5] == "<UNETLoader-out>"
     loaders = _called("ModelPatchLoader")
     assert len(loaders) == 1 and loaders[0]["name"] == "union.safetensors"
     patches = _called("QwenImageDiffsynthControlnet")

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -234,8 +234,14 @@ class ToobusyZImageTurbo:
 
         return base
 
-    RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT")
-    RETURN_NAMES = ("image", "latent", "width", "height")
+    # model/clip/vae/conditioning are passthrough outputs of what this node
+    # loaded and prepared (LoRA + shift applied; zit_control patches are NOT
+    # carried — control maps are sized to this node's own run). They feed
+    # follow-up stages (e.g. toobusy Hires Upscale + a second sampler pass)
+    # without re-adding loader nodes. Appended after the original outputs so
+    # existing workflows keep their link slots.
+    RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT", "MODEL", "CLIP", "VAE", "CONDITIONING", "CONDITIONING")
+    RETURN_NAMES = ("image", "latent", "width", "height", "model", "clip", "vae", "positive", "negative")
     FUNCTION = "generate"
     CATEGORY = "toobusy/Make"
 
@@ -345,6 +351,11 @@ class ToobusyZImageTurbo:
             )[0]
             width, height = target_w, target_h
 
+        # Passthrough model: LoRA + shift applied, but before any zit_control
+        # patch (control maps are bound to this run's resolution and would
+        # misbehave at a different second-pass size).
+        export_model = model
+
         # ControlNet module (optional): patch the final model — override/LoRA
         # included — once the generation size is known, so control maps match
         # the latent. Without a connected module nothing changes.
@@ -366,7 +377,7 @@ class ToobusyZImageTurbo:
         )[0]
         image = _call_node("VAEDecode", samples=sampled, vae=vae)[0]
 
-        return (image, sampled, width, height)
+        return (image, sampled, width, height, export_model, clip, vae, positive_cond, negative_cond)
 
 
 NODE_CLASS_MAPPINGS = {

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -234,14 +234,17 @@ class ToobusyZImageTurbo:
 
         return base
 
-    # model/clip/vae/conditioning are passthrough outputs of what this node
-    # loaded and prepared (LoRA + shift applied; zit_control patches are NOT
-    # carried — control maps are sized to this node's own run). They feed
-    # follow-up stages (e.g. toobusy Hires Upscale + a second sampler pass)
-    # without re-adding loader nodes. Appended after the original outputs so
-    # existing workflows keep their link slots.
-    RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT", "MODEL", "CLIP", "VAE", "CONDITIONING", "CONDITIONING")
-    RETURN_NAMES = ("image", "latent", "width", "height", "model", "clip", "vae", "positive", "negative")
+    # Passthrough outputs of what this node loaded and prepared, so follow-up
+    # stages (toobusy Hires Upscale + a second sampler pass) need no external
+    # loaders or re-typed prompts. Two model flavors:
+    #   model       — exactly what sampled here: LoRA + shift + any zit_control
+    #                 patches (control maps are bound to THIS run's resolution;
+    #                 at a different second-pass size prefer model_clean).
+    #   model_clean — the model as loaded (override or internal), before LoRA /
+    #                 shift / controlnet: swap LoRAs or re-shift externally.
+    # Appended after the original outputs so existing workflows keep their slots.
+    RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT", "MODEL", "MODEL", "CLIP", "VAE", "CONDITIONING", "CONDITIONING")
+    RETURN_NAMES = ("image", "latent", "width", "height", "model", "model_clean", "clip", "vae", "positive", "negative")
     FUNCTION = "generate"
     CATEGORY = "toobusy/Make"
 
@@ -302,6 +305,10 @@ class ToobusyZImageTurbo:
             print("[toobusy Z-Image Turbo] Using internal VAE loader.")
             vae = _call_node("VAELoader", vae_name=vae_name)[0]
 
+        # Clean passthrough: the model exactly as loaded, before LoRA / shift /
+        # controlnet — for swapping LoRAs in a second pass.
+        model_clean = model
+
         lora_slots = max(0, min(MAX_LORA_SLOTS, int(lora_slots)))
         for slot in range(1, lora_slots + 1):
             enabled = lora_kwargs.get(f"lora_{slot}_enable", False)
@@ -351,11 +358,6 @@ class ToobusyZImageTurbo:
             )[0]
             width, height = target_w, target_h
 
-        # Passthrough model: LoRA + shift applied, but before any zit_control
-        # patch (control maps are bound to this run's resolution and would
-        # misbehave at a different second-pass size).
-        export_model = model
-
         # ControlNet module (optional): patch the final model — override/LoRA
         # included — once the generation size is known, so control maps match
         # the latent. Without a connected module nothing changes.
@@ -377,7 +379,7 @@ class ToobusyZImageTurbo:
         )[0]
         image = _call_node("VAEDecode", samples=sampled, vae=vae)[0]
 
-        return (image, sampled, width, height, export_model, clip, vae, positive_cond, negative_cond)
+        return (image, sampled, width, height, model, model_clean, clip, vae, positive_cond, negative_cond)
 
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
Operator feedback: feeding toobusy Hires Upscale required pulling a
separate Load VAE node even though Z-Image Turbo had already loaded
one. The node now also outputs what it loaded and prepared: model
(LoRA + shift applied; zit_control patches excluded since control
maps are bound to this run resolution), clip, vae, and the encoded
positive/negative conditioning - so Z-Image Turbo -> Hires Upscale ->
KSampler -> VAEDecode wires up with zero external loaders or
re-typed prompts. Existing output slots keep their order; the new
ones are appended.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
