### PR TITLE
Z-Image Turbo: fuzzy auto-detection of default models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### Changed
+- `toobusy Z-Image Turbo`의 **모델 기본값 자동 감지** 개선: 정확한 파일명 일치
+  대신 퍼지 스캔(zimage/z-image/z_image + turbo/textEncoder/vae 등)으로 모델
+  폴더에서 Z-Image 파일을 찾아 새 노드의 기본값으로 잡습니다. 파일명/폴더
+  구성이 달라도(z_image_bf16, ZIT/zImage_* 등) 처음부터 올바른 모델이 선택됩니다.
+  (운영자 피드백)
 - `toobusy Z-Image Turbo`에 **passthrough 출력 6개 추가**: `model`(LoRA+shift+
   zit_control까지 — 이 노드가 실제 샘플링한 그 모델), `model_clean`(로드 직후
   원본 — 2차 패스에서 LoRA를 갈아끼울 때), `clip`/`vae`, `positive`/`negative`

--- a/tests/test_zimage_resolution_i2i.py
+++ b/tests/test_zimage_resolution_i2i.py
@@ -115,6 +115,32 @@ def test_output_slot_order_is_backward_compatible():
     assert names[4:6] == ("model", "model_clean")
 
 
+# --- model auto-detection ----------------------------------------------------
+
+def test_scan_picks_zimage_model_regardless_of_naming():
+    names = ["aaa_first.safetensors", "z_image_bf16.safetensors", "wan21_14B.safetensors"]
+    picked = _zit._scan_for(names, [("zimage", "turbo"), ("zimage",)])
+    assert picked == "z_image_bf16.safetensors"
+
+
+def test_scan_prefers_turbo_variant_over_plain():
+    names = ["z_image_bf16.safetensors", "ZIT\\Z-Image-Turbo_fp8.safetensors"]
+    picked = _zit._scan_for(names, [("zimage", "turbo"), ("zimage",)])
+    assert picked == "ZIT\\Z-Image-Turbo_fp8.safetensors"
+
+
+def test_scan_finds_text_encoder_and_vae_in_subfolders():
+    clips = ["qwen3_4b.safetensors", "ZIT\\zImage_textEncoder.safetensors"]
+    assert _zit._scan_for(clips, [("zimage", "textencoder"), ("zimage",)]) == "ZIT\\zImage_textEncoder.safetensors"
+    vaes = ["sdxl_vae.safetensors", "ZIT\\zImage_vae.safetensors"]
+    assert _zit._scan_for(vaes, [("zimage", "vae"), ("zimage",)]) == "ZIT\\zImage_vae.safetensors"
+
+
+def test_scan_falls_back_to_first_when_nothing_matches():
+    names = ["unrelated_a.safetensors", "unrelated_b.safetensors"]
+    assert _zit._scan_for(names, [("zimage",)]) == "unrelated_a.safetensors"
+
+
 # --- INPUT_TYPES exposure --------------------------------------------------
 
 def test_exposes_image_width_height_inputs():

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -35,6 +35,25 @@ def _first_existing(names, preferred):
     return names[0]
 
 
+def _normalized(name):
+    """Lowercased, separator-free view for fuzzy matching: 'ZIT\\Z-Image_Turbo'
+    and 'z_image_turbo' both become 'zitzimageturbo'."""
+    return name.lower().replace("-", "").replace("_", "").replace(" ", "")
+
+
+def _scan_for(names, keyword_groups, fallback_preferred=()):
+    """First name matching the earliest keyword group (all keywords of a group
+    must appear in the normalized name). Groups are ordered best-first, so a
+    'zimage turbo' file beats a plain 'zimage' one. Falls back to exact
+    preferred names, then to the folder's first entry."""
+    normalized = [(name, _normalized(name)) for name in names]
+    for keywords in keyword_groups:
+        for name, key in normalized:
+            if all(keyword in key for keyword in keywords):
+                return name
+    return _first_existing(names, fallback_preferred)
+
+
 def _model_names():
     names = _folder_list("diffusion_models", [])
     if not names:
@@ -166,9 +185,34 @@ class ToobusyZImageTurbo:
 
         base = {
             "required": {
-                "model_name": (model_names, {"default": _first_existing(model_names, ["ZIT/zImage_turbo.safetensors"])}),
-                "clip_name": (clip_names, {"default": _first_existing(clip_names, ["ZIT/zImage_textEncoder.safetensors"])}),
-                "vae_name": (vae_names, {"default": _first_existing(vae_names, ["FLUX1/ae.safetensors"])}),
+                # Auto-detect Z-Image files by fuzzy name scan, so a freshly
+                # added node starts with the right models regardless of how
+                # the user named or foldered them (z_image_bf16, ZIT/zImage_*,
+                # Z-Image-Turbo, ...).
+                "model_name": (
+                    model_names,
+                    {"default": _scan_for(
+                        model_names,
+                        [("zimage", "turbo"), ("zimage",)],
+                        fallback_preferred=["ZIT/zImage_turbo.safetensors"],
+                    )},
+                ),
+                "clip_name": (
+                    clip_names,
+                    {"default": _scan_for(
+                        clip_names,
+                        [("zimage", "textencoder"), ("zimage", "text"), ("zimage",), ("lumina",)],
+                        fallback_preferred=["ZIT/zImage_textEncoder.safetensors"],
+                    )},
+                ),
+                "vae_name": (
+                    vae_names,
+                    {"default": _scan_for(
+                        vae_names,
+                        [("zimage", "vae"), ("zimage",), ("flux", "ae"), ("ae.safetensors",)],
+                        fallback_preferred=["FLUX1/ae.safetensors"],
+                    )},
+                ),
                 "positive": ("STRING", {"default": "", "multiline": True}),
                 "negative": ("STRING", {"default": "", "multiline": True}),
                 "ratio_preset": (list(RATIO_PRESETS.keys()), {"default": "2:3"}),


### PR DESCRIPTION
Operator feedback: a freshly added Z-Image Turbo node picked wrong
default models. The old default logic only matched one exact filename
(ZIT/zImage_turbo.safetensors) and otherwise fell back to the first
folder entry. Defaults now fuzzy-scan the model folders (normalized
name contains zimage [+ turbo / textencoder / vae], with lumina and
flux-ae fallbacks for clip/vae), so z_image_bf16 / ZIT/zImage_* /
Z-Image-Turbo style names all get picked up automatically.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
