### PR TITLE
Extend model auto-detection to all loader nodes + Flux2 Klein review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`toobusy Flux2 Klein` 실행 불가 버그 수정**(검수): 레퍼런스 컨디셔닝이 백엔드에
+  존재하지 않는 서브그래프 UUID 클래스를 호출하고 있었음 → 원본 워크플로우의 실제
+  체인(`ImageScaleToTotalPixels`(lanczos·1MP) → `VAEEncode` → `ReferenceLatent`)
+  으로 교체. 내부 CLIP 로더 타입 `lumina2` → `flux2` 수정, 자체 `_call_node` 사본을
+  V3 기본값 채움이 포함된 공용 헬퍼로 교체.
+
 ### Changed
+- **모델 기본값 자동 감지를 전 노드로 확대**: `_scan_for`(퍼지 스캔)를 공용 모듈로
+  승격하고 `toobusy Ideogram4 T2I`(조건/무조건 모델 구분 포함)와 `toobusy Flux2
+  Klein`에 적용. 새 노드를 꺼내면 폴더에서 알맞은 모델이 자동 선택됩니다.
+- `toobusy Flux2 Klein`에 passthrough 출력 추가(`model`/`model_clean`/`clip`/
+  `vae`/`positive`) — Z-Image Turbo와 같은 규약, 기존 슬롯 순서 유지.
 - `toobusy Z-Image Turbo`의 **모델 기본값 자동 감지** 개선: 정확한 파일명 일치
   대신 퍼지 스캔(zimage/z-image/z_image + turbo/textEncoder/vae 등)으로 모델
   폴더에서 Z-Image 파일을 찾아 새 노드의 기본값으로 잡습니다. 파일명/폴더

--- a/flux2_klein_node/flux2_klein.py
+++ b/flux2_klein_node/flux2_klein.py
@@ -1,7 +1,11 @@
-import inspect
 import math
 
-from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _default_sampler_name, _sampler_names
+from ..ltx23_compact_sampler_node.ltx23_compact_sampler import (
+    _call_node,
+    _default_sampler_name,
+    _sampler_names,
+    _scan_for,
+)
 
 
 RATIO_PRESETS = {
@@ -17,41 +21,6 @@ RATIO_PRESETS = {
 MAX_LORA_SLOTS = 5
 MAX_REFERENCE_SLOTS = 3
 
-# The operator workflow exports the Flux2 Klein reference conditioners with
-# UUID class ids. Keep them as constants so the folded node calls the same graph.
-KLEIN_REF1_NODE = "6f5ae6ae-be1f-4f5c-a5af-178cfb6f7d59"
-KLEIN_REF2_NODE = "49cbf2f1-9ad3-46a0-a601-3dcd6841d1d5"
-KLEIN_REF3_NODE = "27a7eb01-8cd8-445b-a655-f79d702ab0c8"
-
-
-def _node_class(class_name):
-    import nodes
-
-    try:
-        return nodes.NODE_CLASS_MAPPINGS[class_name]
-    except KeyError as exc:
-        raise RuntimeError(
-            f"Required ComfyUI node '{class_name}' is not available. "
-            "This folded Flux2 Klein workflow needs Flux2/Klein reference nodes "
-            "installed in the current ComfyUI environment."
-        ) from exc
-
-
-def _call_node(class_name, **kwargs):
-    cls = _node_class(class_name)
-    node = cls()
-    fn_name = getattr(cls, "FUNCTION", None)
-    if not fn_name:
-        raise RuntimeError(f"Node '{class_name}' does not define FUNCTION.")
-
-    fn = getattr(node, fn_name)
-    signature = inspect.signature(fn)
-    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
-        return fn(**kwargs)
-
-    filtered = {key: value for key, value in kwargs.items() if key in signature.parameters}
-    return fn(**filtered)
-
 
 def _folder_list(kind, fallback):
     try:
@@ -61,13 +30,6 @@ def _folder_list(kind, fallback):
         return names or fallback
     except Exception:
         return fallback
-
-
-def _first_existing(names, preferred):
-    for name in preferred:
-        if name in names:
-            return name
-    return names[0]
 
 
 def _model_names():
@@ -121,7 +83,10 @@ def _image_dims(image):
 
 
 def _load_clip(clip_name):
-    return _call_node("CLIPLoader", clip_name=clip_name, type="lumina2", device="default")[0]
+    # Flux2 Klein uses a Qwen3-based text encoder with the "flux2" CLIP type
+    # (the source workflow loads it via CLIPLoaderGGUF with type=flux2; the
+    # GGUF file itself can flow in through clip_override).
+    return _call_node("CLIPLoader", clip_name=clip_name, type="flux2", device="default")[0]
 
 
 class ToobusyFlux2Klein:
@@ -143,9 +108,32 @@ class ToobusyFlux2Klein:
 
         base = {
             "required": {
-                "model_name": (model_names, {"default": _first_existing(model_names, ["FLUX2/flux-2-klein-9b-kv-fp8.safetensors", "FLUX2\\flux-2-klein-9b-kv-fp8.safetensors"])}),
-                "clip_name": (clip_names, {"default": _first_existing(clip_names, ["flux2/qwen_3_8b_fp8mixed.safetensors", "flux2\\qwen_3_8b_fp8mixed.safetensors"])}),
-                "vae_name": (vae_names, {"default": _first_existing(vae_names, ["flux2/flux2-vae.safetensors", "flux2\\flux2-vae.safetensors"])}),
+                # Fuzzy auto-detection (shared _scan_for): a fresh node picks
+                # the Flux2 Klein files regardless of naming/foldering.
+                "model_name": (
+                    model_names,
+                    {"default": _scan_for(
+                        model_names,
+                        [("flux2", "klein"), ("flux", "klein"), ("klein",), ("flux2",)],
+                        fallback_preferred=["FLUX2/flux-2-klein-9b-kv-fp8.safetensors"],
+                    )},
+                ),
+                "clip_name": (
+                    clip_names,
+                    {"default": _scan_for(
+                        clip_names,
+                        [("qwen", "klein"), ("qwen3", "8b"), ("qwen", "8b"), ("qwen",)],
+                        fallback_preferred=["flux2/qwen_3_8b_fp8mixed.safetensors"],
+                    )},
+                ),
+                "vae_name": (
+                    vae_names,
+                    {"default": _scan_for(
+                        vae_names,
+                        [("flux2", "vae"), ("flux2",), ("flux", "ae")],
+                        fallback_preferred=["flux2/flux2-vae.safetensors"],
+                    )},
+                ),
                 "positive": (
                     "STRING",
                     {
@@ -205,8 +193,14 @@ class ToobusyFlux2Klein:
 
         return base
 
-    RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT")
-    RETURN_NAMES = ("image", "latent", "width", "height")
+    # Passthrough outputs (toobusy convention, same as Z-Image Turbo):
+    #   model       — what sampled here (LoRA + Flux KV cache applied)
+    #   model_clean — as loaded, before any patching (swap LoRAs externally)
+    # plus clip / vae / the encoded positive conditioning, so a Hires Upscale +
+    # second sampler pass needs no external loaders. Appended after the
+    # original outputs to keep existing link slots.
+    RETURN_TYPES = ("IMAGE", "LATENT", "INT", "INT", "MODEL", "MODEL", "CLIP", "VAE", "CONDITIONING")
+    RETURN_NAMES = ("image", "latent", "width", "height", "model", "model_clean", "clip", "vae", "positive")
     FUNCTION = "generate"
     CATEGORY = "toobusy/Make"
 
@@ -272,21 +266,21 @@ class ToobusyFlux2Klein:
                 )
                 print(f"[toobusy Flux2 Klein] LoRA slot {slot} applied: {lora_name} @ {lora_strength}")
 
+        # Clean passthrough: the model as loaded, before LoRA / KV cache.
+        model_clean = model
+
         model = _call_node("FluxKVCache", model=model)[0]
         conditioning = _call_node("CLIPTextEncode", clip=clip, text=positive)[0]
 
+        # Reference conditioning. The source workflow's per-reference subgraph
+        # is ImageScaleToTotalPixels (lanczos, 1MP) -> VAEEncode ->
+        # ReferenceLatent, chained on the conditioning — all core nodes.
         reference_slots = max(0, min(MAX_REFERENCE_SLOTS, int(reference_slots)))
         references = {
             1: reference_1_image,
             2: reference_2_image,
             3: reference_3_image,
         }
-        ref_nodes = {
-            1: KLEIN_REF1_NODE,
-            2: KLEIN_REF2_NODE,
-            3: KLEIN_REF3_NODE,
-        }
-        base_image = None
         first_active_image = None
 
         for slot in range(1, reference_slots + 1):
@@ -301,20 +295,25 @@ class ToobusyFlux2Klein:
             if first_active_image is None:
                 first_active_image = image
 
-            if slot == 1:
-                conditioning, base_image = _call_node(ref_nodes[slot], on_false=conditioning, vae=vae, image=image)
-            elif slot == 2:
-                conditioning = _call_node(ref_nodes[slot], image=image, vae=vae, conditioning=conditioning)[0]
-            else:
-                conditioning = _call_node(ref_nodes[slot], vae=vae, conditioning=conditioning, image=image)[0]
+            scaled = _call_node(
+                "ImageScaleToTotalPixels",
+                image=image,
+                upscale_method="lanczos",
+                megapixels=1.0,
+            )[0]
+            reference_latent = _call_node("VAEEncode", pixels=scaled, vae=vae)[0]
+            conditioning = _call_node(
+                "ReferenceLatent",
+                conditioning=conditioning,
+                latent=reference_latent,
+            )[0]
             print(f"[toobusy Flux2 Klein] Reference #{slot} applied.")
 
         if int(width) > 0 and int(height) > 0:
             target_w = _round_to(int(width), divisible_by)
             target_h = _round_to(int(height), divisible_by)
         else:
-            size_image = base_image if base_image is not None else first_active_image
-            target_w, target_h = _image_dims(size_image) if size_image is not None else (0, 0)
+            target_w, target_h = _image_dims(first_active_image) if first_active_image is not None else (0, 0)
             if target_w <= 0 or target_h <= 0:
                 target_w, target_h = _resolution_from_megapixels(ratio_preset, megapixels, divisible_by)
 
@@ -332,7 +331,7 @@ class ToobusyFlux2Klein:
             latent_image=latent_image,
         )[0]
         image = _call_node("VAEDecode", samples=sampled, vae=vae)[0]
-        return (image, sampled, target_w, target_h)
+        return (image, sampled, target_w, target_h, model, model_clean, clip, vae, conditioning)
 
 
 NODE_CLASS_MAPPINGS = {

--- a/ideogram4_t2i_node/ideogram4_t2i.py
+++ b/ideogram4_t2i_node/ideogram4_t2i.py
@@ -1,6 +1,11 @@
 import math
 
-from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _call_node, _sampler_names
+from ..ltx23_compact_sampler_node.ltx23_compact_sampler import (
+    _call_node,
+    _normalized,
+    _sampler_names,
+    _scan_for,
+)
 
 
 RATIO_PRESETS = {
@@ -51,13 +56,6 @@ def _folder_list(kind, fallback):
         return names or fallback
     except Exception:
         return fallback
-
-
-def _first_existing(names, preferred):
-    for name in preferred:
-        if name in names:
-            return name
-    return names[0] if names else preferred[0]
 
 
 def _diffusion_model_names():
@@ -112,19 +110,42 @@ class ToobusyIdeogram4T2I:
 
         inputs = {
             "required": {
+                # Fuzzy auto-detection (shared _scan_for): a fresh node picks
+                # the right Ideogram4 files no matter how they're named or
+                # foldered. The conditional model scan excludes "uncond" names
+                # so the two model slots never grab the same file.
                 "model_name": (
                     diffusion_names,
-                    {"default": _first_existing(diffusion_names, ["ideogram4_fp8_scaled.safetensors"])},
+                    {"default": _scan_for(
+                        [n for n in diffusion_names if "uncond" not in _normalized(n)] or diffusion_names,
+                        [("ideogram4",), ("ideogram",)],
+                        fallback_preferred=["ideogram4_fp8_scaled.safetensors"],
+                    )},
                 ),
                 "unconditional_model_name": (
                     diffusion_names,
-                    {"default": _first_existing(diffusion_names, ["ideogram4_unconditional_fp8_scaled.safetensors"])},
+                    {"default": _scan_for(
+                        diffusion_names,
+                        [("ideogram4", "unconditional"), ("ideogram", "uncond")],
+                        fallback_preferred=["ideogram4_unconditional_fp8_scaled.safetensors"],
+                    )},
                 ),
                 "clip_name": (
                     clip_names,
-                    {"default": _first_existing(clip_names, ["qwen3vl_8b_fp8_scaled.safetensors"])},
+                    {"default": _scan_for(
+                        clip_names,
+                        [("qwen3vl",), ("qwen", "vl"), ("ideogram",)],
+                        fallback_preferred=["qwen3vl_8b_fp8_scaled.safetensors"],
+                    )},
                 ),
-                "vae_name": (vae_names, {"default": _first_existing(vae_names, ["flux2-vae.safetensors"])}),
+                "vae_name": (
+                    vae_names,
+                    {"default": _scan_for(
+                        vae_names,
+                        [("flux2", "vae"), ("flux2",), ("flux", "ae")],
+                        fallback_preferred=["flux2-vae.safetensors"],
+                    )},
+                ),
                 "prompt": ("STRING", {"default": DEFAULT_PROMPT, "multiline": True}),
                 "quality": (list(QUALITY_PRESETS.keys()) + ["Custom"], {"default": "Turbo"}),
                 "steps": (

--- a/ltx23_compact_sampler_node/ltx23_compact_sampler.py
+++ b/ltx23_compact_sampler_node/ltx23_compact_sampler.py
@@ -9,8 +9,36 @@ def _node_class(class_name):
     except KeyError as exc:
         raise RuntimeError(
             f"Required ComfyUI node '{class_name}' is not available. "
-            "Install/enable the LTXV nodes used by this workflow first."
+            "This toobusy fold calls it internally — install/enable the node "
+            "pack (or update ComfyUI) that provides it."
         ) from exc
+
+
+def _first_existing(names, preferred):
+    for name in preferred:
+        if name in names:
+            return name
+    return names[0]
+
+
+def _normalized(name):
+    """Lowercased, separator-free view for fuzzy matching: 'ZIT\\Z-Image_Turbo'
+    and 'z_image_turbo' both become 'zitzimageturbo'."""
+    return name.lower().replace("-", "").replace("_", "").replace(" ", "")
+
+
+def _scan_for(names, keyword_groups, fallback_preferred=()):
+    """First name matching the earliest keyword group (all keywords of a group
+    must appear in the normalized name). Groups are ordered best-first, so a
+    'zimage turbo' file beats a plain 'zimage' one. Falls back to exact
+    preferred names, then to the folder's first entry. Shared by every fold
+    that auto-detects its default model files."""
+    normalized = [(name, _normalized(name)) for name in names]
+    for keywords in keyword_groups:
+        for name, key in normalized:
+            if all(keyword in key for keyword in keywords):
+                return name
+    return _first_existing(names, fallback_preferred)
 
 
 def _fill_input_defaults(cls, kwargs, params, has_var_keyword):

--- a/tests/test_flux2_klein.py
+++ b/tests/test_flux2_klein.py
@@ -1,0 +1,169 @@
+"""Regression tests for toobusy Flux2 Klein (post-review fixes).
+
+Locks in the review fixes on the folded Flux2 Klein node:
+
+  * references are applied through REAL core nodes
+    (ImageScaleToTotalPixels 1MP lanczos -> VAEEncode -> ReferenceLatent),
+    chained on the conditioning — not the unreachable subgraph-UUID classes
+    the first prototype called;
+  * the internal CLIP loader uses type="flux2" (not lumina2);
+  * disabled / unconnected reference slots are skipped;
+  * default sizing follows the first active reference image;
+  * passthrough outputs (model / model_clean / clip / vae / positive) follow
+    the toobusy convention with backward-compatible slot order.
+
+Standalone- and pytest-runnable, no ComfyUI runtime.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+_CALLS = []
+
+
+def _install_stubs():
+    folder_paths = types.ModuleType("folder_paths")
+    folder_paths.get_filename_list = lambda kind: []
+    sys.modules["folder_paths"] = folder_paths
+
+    def fake_call_node(node_type, **kwargs):
+        _CALLS.append((node_type, kwargs))
+        return [f"<{node_type}-out>"]
+
+    pkg = types.ModuleType("toobusy")
+    pkg.__path__ = [ROOT]
+    sys.modules["toobusy"] = pkg
+
+    sub = types.ModuleType("toobusy.ltx23_compact_sampler_node")
+    sub.__path__ = [os.path.join(ROOT, "ltx23_compact_sampler_node")]
+    sys.modules["toobusy.ltx23_compact_sampler_node"] = sub
+
+    ltx_path = os.path.join(ROOT, "ltx23_compact_sampler_node", "ltx23_compact_sampler.py")
+    spec = importlib.util.spec_from_file_location(
+        "toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler", ltx_path
+    )
+    samp = importlib.util.module_from_spec(spec)
+    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
+    spec.loader.exec_module(samp)
+    samp._call_node = fake_call_node
+    samp._sampler_names = lambda: ["euler", "res_multistep"]
+    samp._default_sampler_name = lambda names: names[0]
+
+
+def _load(modname, relpath):
+    path = os.path.join(ROOT, relpath)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_stubs()
+_mod = _load(
+    "toobusy.flux2_klein_node.flux2_klein",
+    os.path.join("flux2_klein_node", "flux2_klein.py"),
+)
+
+
+class _FakeImage:
+    def __init__(self, height, width):
+        self.shape = (1, height, width, 3)
+
+
+def _generate(**overrides):
+    _CALLS.clear()
+    kwargs = dict(
+        model_name="m", clip_name="c", vae_name="v", positive="p",
+        ratio_preset="1:1", megapixels=1.0, divisible_by=32, batch_size=1,
+        seed=1, steps=4, sampler_name="euler", lora_slots=0, reference_slots=3,
+        reference_1_enable=True, reference_2_enable=True, reference_3_enable=True,
+    )
+    kwargs.update(overrides)
+    return _mod.ToobusyFlux2Klein().generate(**kwargs)
+
+
+def _called(node_type):
+    return [kw for nt, kw in _CALLS if nt == node_type]
+
+
+def test_references_use_real_core_chain():
+    _generate(reference_1_image=_FakeImage(512, 768), reference_2_image=_FakeImage(256, 256))
+    scales = _called("ImageScaleToTotalPixels")
+    assert len(scales) == 2
+    assert all(kw["upscale_method"] == "lanczos" and kw["megapixels"] == 1.0 for kw in scales)
+    assert len(_called("VAEEncode")) == 2
+    refs = _called("ReferenceLatent")
+    assert len(refs) == 2
+    # The second ReferenceLatent chains on the first one's conditioning output.
+    assert refs[0]["conditioning"] == "<CLIPTextEncode-out>"
+    assert refs[1]["conditioning"] == "<ReferenceLatent-out>"
+    # No UUID-typed calls anywhere (the prototype's unreachable subgraph ids).
+    assert all("-" not in nt or nt.count("-") < 4 for nt, _ in _CALLS)
+
+
+def test_disabled_or_missing_references_are_skipped():
+    _generate(reference_1_image=_FakeImage(512, 512), reference_1_enable=False)
+    assert not _called("ReferenceLatent")
+
+
+def test_internal_clip_loader_uses_flux2_type():
+    _generate()
+    clips = _called("CLIPLoader")
+    assert clips and clips[0]["type"] == "flux2"
+
+
+def test_size_follows_first_active_reference():
+    _generate(reference_1_image=_FakeImage(510, 770))
+    latents = _called("EmptyFlux2LatentImage")
+    assert latents and (latents[0]["width"], latents[0]["height"]) == (768, 504)
+
+
+def test_manual_size_wins_over_reference():
+    _generate(reference_1_image=_FakeImage(512, 512), width=768, height=1280)
+    latents = _called("EmptyFlux2LatentImage")
+    assert latents and (latents[0]["width"], latents[0]["height"]) == (768, 1280)
+
+
+def test_passthrough_outputs_and_slot_order():
+    result = _generate()
+    assert len(result) == 9
+    image, latent, w, h, model, model_clean, clip, vae, positive = result
+    assert model == "<FluxKVCache-out>", "final model includes the KV cache patch"
+    assert model_clean == "<UNETLoader-out>", "clean model predates LoRA/KV"
+    assert clip == "<CLIPLoader-out>" and vae == "<VAELoader-out>"
+    types_ = _mod.ToobusyFlux2Klein.RETURN_TYPES
+    assert types_[:4] == ("IMAGE", "LATENT", "INT", "INT"), "existing slots must not move"
+
+
+def test_default_scan_keywords_find_operator_files():
+    scan = sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"]._scan_for
+    models = ["wan21_14B.safetensors", "FLUX2\\flux-2-klein-9b-fp8.safetensors"]
+    assert scan(models, [("flux2", "klein"), ("klein",)]) == "FLUX2\\flux-2-klein-9b-fp8.safetensors"
+    clips = ["ZIT\\zImage_textEncoder.safetensors", "flux2\\qwen38BFluxKlein9BTE_38b.safetensors"]
+    assert scan(clips, [("qwen", "klein"), ("qwen",)]) == "flux2\\qwen38BFluxKlein9BTE_38b.safetensors"
+    vaes = ["sdxl_vae.safetensors", "flux2\\flux2-vae.safetensors"]
+    assert scan(vaes, [("flux2", "vae"), ("flux2",)]) == "flux2\\flux2-vae.safetensors"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+            except Exception as exc:  # noqa: BLE001 - regression visibility
+                failures += 1
+                print(f"ERROR {name}: {type(exc).__name__}: {exc}")
+    if failures:
+        print(f"\n{failures} test(s) failed")
+        sys.exit(1)
+    print("\nall tests passed")

--- a/tests/test_model_overrides.py
+++ b/tests/test_model_overrides.py
@@ -49,11 +49,18 @@ def _install_stubs():
     sub.__path__ = [os.path.join(ROOT, "ltx23_compact_sampler_node")]
     sys.modules["toobusy.ltx23_compact_sampler_node"] = sub
 
-    samp = types.ModuleType("toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler")
+    # Load the REAL shared module (the nodes import _scan_for/_normalized from
+    # it now), then patch only the runtime-touching helpers.
+    ltx_path = os.path.join(ROOT, "ltx23_compact_sampler_node", "ltx23_compact_sampler.py")
+    spec = importlib.util.spec_from_file_location(
+        "toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler", ltx_path
+    )
+    samp = importlib.util.module_from_spec(spec)
+    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
+    spec.loader.exec_module(samp)
     samp._call_node = fake_call_node
     samp._sampler_names = lambda: ["res_multistep", "euler"]
     samp._default_sampler_name = lambda names: names[0]
-    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
 
 
 def _load(modname, relpath):

--- a/tests/test_zimage_resolution_i2i.py
+++ b/tests/test_zimage_resolution_i2i.py
@@ -39,11 +39,18 @@ def _install_stubs():
     sub.__path__ = [os.path.join(ROOT, "ltx23_compact_sampler_node")]
     sys.modules["toobusy.ltx23_compact_sampler_node"] = sub
 
-    samp = types.ModuleType("toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler")
+    # Load the REAL shared module (z_image imports _scan_for from it now),
+    # then patch only the runtime-touching helpers.
+    ltx_path = os.path.join(ROOT, "ltx23_compact_sampler_node", "ltx23_compact_sampler.py")
+    spec = importlib.util.spec_from_file_location(
+        "toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler", ltx_path
+    )
+    samp = importlib.util.module_from_spec(spec)
+    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
+    spec.loader.exec_module(samp)
     samp._call_node = fake_call_node
     samp._sampler_names = lambda: ["res_multistep", "euler"]
     samp._default_sampler_name = lambda names: names[0]
-    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
 
 
 def _load(modname, relpath):

--- a/tests/test_zit_controlnet.py
+++ b/tests/test_zit_controlnet.py
@@ -47,11 +47,18 @@ def _install_stubs():
     sub.__path__ = [os.path.join(ROOT, "ltx23_compact_sampler_node")]
     sys.modules["toobusy.ltx23_compact_sampler_node"] = sub
 
-    samp = types.ModuleType("toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler")
+    # Load the REAL shared module (z_image imports _scan_for from it now),
+    # then patch only the runtime-touching helpers.
+    ltx_path = os.path.join(ROOT, "ltx23_compact_sampler_node", "ltx23_compact_sampler.py")
+    spec = importlib.util.spec_from_file_location(
+        "toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler", ltx_path
+    )
+    samp = importlib.util.module_from_spec(spec)
+    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
+    spec.loader.exec_module(samp)
     samp._call_node = fake_call_node
     samp._sampler_names = lambda: ["res_multistep", "euler"]
     samp._default_sampler_name = lambda names: names[0]
-    sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
 
 
 def _load(modname, relpath):

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -1,6 +1,11 @@
 import math
 
-from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _call_node, _default_sampler_name, _sampler_names
+from ..ltx23_compact_sampler_node.ltx23_compact_sampler import (
+    _call_node,
+    _default_sampler_name,
+    _sampler_names,
+    _scan_for,
+)
 
 
 RATIO_PRESETS = {
@@ -28,30 +33,7 @@ def _folder_list(kind, fallback):
         return fallback
 
 
-def _first_existing(names, preferred):
-    for name in preferred:
-        if name in names:
-            return name
-    return names[0]
-
-
-def _normalized(name):
-    """Lowercased, separator-free view for fuzzy matching: 'ZIT\\Z-Image_Turbo'
-    and 'z_image_turbo' both become 'zitzimageturbo'."""
-    return name.lower().replace("-", "").replace("_", "").replace(" ", "")
-
-
-def _scan_for(names, keyword_groups, fallback_preferred=()):
-    """First name matching the earliest keyword group (all keywords of a group
-    must appear in the normalized name). Groups are ordered best-first, so a
-    'zimage turbo' file beats a plain 'zimage' one. Falls back to exact
-    preferred names, then to the folder's first entry."""
-    normalized = [(name, _normalized(name)) for name in names]
-    for keywords in keyword_groups:
-        for name, key in normalized:
-            if all(keyword in key for keyword in keywords):
-                return name
-    return _first_existing(names, fallback_preferred)
+# _scan_for / fuzzy model auto-detection lives in the shared ltx23 module now.
 
 
 def _model_names():


### PR DESCRIPTION
Operator request: every node that loads models should auto-detect its
defaults the way Z-Image Turbo now does. _scan_for/_normalized move to
the shared ltx23 module (the shared _node_class error hint loses its
LTXV-specific wording), Z-Image imports them, and Ideogram4 T2I
(conditional scan excludes 'uncond' names so the two model slots never
grab the same file) and Flux2 Klein get fuzzy defaults.

Review fixes on the Flux2 Klein prototype (operator-directed):
- The reference conditioners called subgraph UUID classes that do not
  exist in the backend registry (guaranteed KeyError at runtime).
  Replaced with the source workflow's real chain per active slot:
  ImageScaleToTotalPixels (lanczos, 1MP) -> VAEEncode ->
  ReferenceLatent, chained on the conditioning.
- Internal CLIP loader type lumina2 -> flux2 (matches the source
  workflow's CLIPLoaderGGUF type and the core CLIPLoader type list).
- The local pre-PR-#54 _call_node copy (vulnerable to the V3
  schema-defaults crash) is replaced by the shared helper.
- Adds toobusy-convention passthrough outputs (model / model_clean /
  clip / vae / positive) with backward-compatible slot order.

Tests: new tests/test_flux2_klein.py (reference chain, clip type,
sizing, passthrough, scan keywords against the operator's real
filenames); the zimage/ideogram/zit suites now load the real shared
module and patch only _call_node.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
