### PR TITLE
Z-Image Turbo: conditioning + latent inputs (close the hires loop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   V3 기본값 채움이 포함된 공용 헬퍼로 교체.
 
 ### Changed
+- `toobusy Z-Image Turbo`에 **컨디셔닝/레이턴트 입력 추가**: `positive_override`/
+  `negative_override`(CONDITIONING — 연결 시 해당 프롬프트 텍스트 무시, 둘 다
+  연결 + LoRA 없음이면 텍스트 인코더 로드 자체를 스킵)와 `latent_override`
+  (LATENT — image 입력보다 우선, 크기는 레이턴트를 따르고 `denoise`가 변환 강도).
+  Z-Image → Hires Upscale → **다시 Z-Image(latent in)** 로 외부 샘플러 없이
+  하이레즈 픽스 루프가 닫힙니다. (운영자 피드백)
 - **모델 기본값 자동 감지를 전 노드로 확대**: `_scan_for`(퍼지 스캔)를 공용 모듈로
   승격하고 `toobusy Ideogram4 T2I`(조건/무조건 모델 구분 포함)와 `toobusy Flux2
   Klein`에 적용. 새 노드를 꺼내면 폴더에서 알맞은 모델이 자동 선택됩니다.

--- a/js/toobusy_z_image_turbo.js
+++ b/js/toobusy_z_image_turbo.js
@@ -87,6 +87,9 @@ const OVERRIDE_INPUT_SPECS = [
     ["model_override", "MODEL"],
     ["clip_override", "CLIP"],
     ["vae_override", "VAE"],
+    ["positive_override", "CONDITIONING"],
+    ["negative_override", "CONDITIONING"],
+    ["latent_override", "LATENT"],
 ];
 
 function setOverrideInputsVisible(node, visible) {
@@ -222,6 +225,11 @@ function imageInputConnected(node) {
     return !!(input && input.link != null);
 }
 
+function latentInputConnected(node) {
+    const input = node.inputs?.find((i) => i.name === "latent_override");
+    return !!(input && input.link != null);
+}
+
 function updateResolutionReadout(node) {
     const readout = findWidget(node, "resolution_readout");
     if (!readout) return;
@@ -244,7 +252,10 @@ function updateResolutionReadout(node) {
         source = `${ratio} @ ${mp.toFixed(2)}MP`;
     }
 
-    if (imageInputConnected(node)) {
+    if (latentInputConnected(node)) {
+        // An external latent wins over everything: size follows the latent.
+        readout.value = "latent in -> size from latent (denoise = strength)";
+    } else if (imageInputConnected(node)) {
         // img2img: a connected image drives the size unless width/height are set.
         readout.value = manual
             ? `img2img -> ${w} x ${h} (source scaled)`

--- a/tests/test_zimage_resolution_i2i.py
+++ b/tests/test_zimage_resolution_i2i.py
@@ -29,6 +29,8 @@ def _install_stubs():
 
     def fake_call_node(node_type, **kwargs):
         _CALLS.append((node_type, kwargs))
+        if node_type == "LoraLoader":
+            return [f"<{node_type}-model>", f"<{node_type}-clip>"]
         return [f"<{node_type}-out>"]
 
     pkg = types.ModuleType("toobusy")
@@ -120,6 +122,47 @@ def test_output_slot_order_is_backward_compatible():
     assert types[4:] == ("MODEL", "MODEL", "CLIP", "VAE", "CONDITIONING", "CONDITIONING")
     names = _zit.ToobusyZImageTurbo.RETURN_NAMES
     assert names[4:6] == ("model", "model_clean")
+
+
+# --- conditioning / latent overrides -----------------------------------------
+
+class _FakeLatent(dict):
+    """Stand-in for a LATENT dict: {"samples": tensor [B, C, H/8, W/8]}."""
+
+    def __init__(self, height_px, width_px):
+        samples = types.SimpleNamespace(shape=(1, 16, height_px // 8, width_px // 8))
+        super().__init__(samples=samples)
+
+
+def test_positive_override_skips_its_text_encode():
+    result = _generate(positive_override="ext-pos")
+    encodes = _called("CLIPTextEncode")
+    assert len(encodes) == 1 and encodes[0]["text"] == "n", "only the negative is encoded"
+    assert result[8] == "ext-pos", "positive passthrough echoes the override"
+
+
+def test_both_overrides_without_lora_skip_clip_loader():
+    result = _generate(positive_override="ext-pos", negative_override="ext-neg")
+    assert not _called("CLIPLoader"), "no prompt to encode and no LoRA -> no CLIP load"
+    assert not _called("CLIPTextEncode")
+    assert result[6] is None, "clip passthrough is None when the loader is skipped"
+    assert result[8] == "ext-pos" and result[9] == "ext-neg"
+
+
+def test_lora_still_loads_clip_with_both_overrides():
+    _generate(
+        positive_override="ext-pos", negative_override="ext-neg",
+        lora_slots=1, lora_1_enable=True, lora_1_name="some.safetensors", lora_1_strength=1.0,
+    )
+    assert _called("CLIPLoader"), "LoRA application needs CLIP even with conditioning overrides"
+
+
+def test_latent_override_wins_and_sets_size():
+    latent = _FakeLatent(height_px=1280, width_px=768)
+    result = _generate(latent_override=latent, image=_FakeImage(height=512, width=512))
+    assert not _called("EmptyLatentImage") and not _called("VAEEncode"), "external latent bypasses both latent sources"
+    assert _called("KSampler")[0]["latent_image"] is latent
+    assert (result[2], result[3]) == (768, 1280), "width/height follow the latent dims"
 
 
 # --- model auto-detection ----------------------------------------------------

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -99,6 +99,15 @@ def _image_dims(image):
     return (width // 8) * 8, (height // 8) * 8
 
 
+def _latent_dims(latent):
+    """Pixel (width, height) of a LATENT dict ({"samples": [B, C, H/8, W/8]})."""
+    try:
+        samples = latent["samples"]
+        return int(samples.shape[-1]) * 8, int(samples.shape[-2]) * 8
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return 0, 0
+
+
 def _apply_zit_control(model, vae, control, width, height):
     """Apply a `toobusy ZIT ControlNet` bundle to the final model. Each active
     entry stacks its own Fun-ControlNet-Union patch (model patches append, so
@@ -236,6 +245,18 @@ class ToobusyZImageTurbo:
                 "model_override": ("MODEL",),
                 "clip_override": ("CLIP",),
                 "vae_override": ("VAE",),
+                "positive_override": (
+                    "CONDITIONING",
+                    {"tooltip": "External positive conditioning. Connected = the positive prompt text is ignored (and the internal CLIP is not even loaded when both overrides are connected and no LoRA is active)."},
+                ),
+                "negative_override": (
+                    "CONDITIONING",
+                    {"tooltip": "External negative conditioning. Connected = the negative prompt text is ignored."},
+                ),
+                "latent_override": (
+                    "LATENT",
+                    {"tooltip": "External starting latent (e.g. from toobusy Hires Upscale). Connected = wins over the image input and the empty latent; 'denoise' is the change strength. Width/height follow the latent."},
+                ),
                 "zit_control": (
                     "ZIT_CONTROL",
                     {"tooltip": "Connect a 'toobusy ZIT ControlNet' module to apply depth/canny/pose Fun-ControlNet-Union model patches. Leave unconnected for plain generation."},
@@ -299,6 +320,9 @@ class ToobusyZImageTurbo:
         model_override=None,
         clip_override=None,
         vae_override=None,
+        positive_override=None,
+        negative_override=None,
+        latent_override=None,
         zit_control=None,
         **lora_kwargs,
     ):
@@ -317,12 +341,28 @@ class ToobusyZImageTurbo:
             print("[toobusy Z-Image Turbo] Using internal MODEL loader.")
             model = _call_node("UNETLoader", unet_name=model_name, weight_dtype="default")[0]
 
+        # Active LoRA list up front: it decides whether CLIP is needed at all.
+        lora_slots = max(0, min(MAX_LORA_SLOTS, int(lora_slots)))
+        active_loras = []
+        for slot in range(1, lora_slots + 1):
+            enabled = lora_kwargs.get(f"lora_{slot}_enable", False)
+            lora_name = lora_kwargs.get(f"lora_{slot}_name", "None")
+            if enabled and lora_name != "None":
+                active_loras.append((lora_name, lora_kwargs.get(f"lora_{slot}_strength", 1.0)))
+
+        # CLIP is only needed to encode a prompt or to apply LoRAs. With both
+        # conditioning overrides connected and no active LoRA, skip loading the
+        # text encoder entirely (the clip passthrough output is None then).
+        need_clip = positive_override is None or negative_override is None or bool(active_loras)
         if clip_override is not None:
             print("[toobusy Z-Image Turbo] Using external CLIP override. Internal CLIP loader ignored.")
             clip = clip_override
-        else:
+        elif need_clip:
             print("[toobusy Z-Image Turbo] Using internal CLIP loader.")
             clip = _call_node("CLIPLoader", clip_name=clip_name, type="lumina2", device="default")[0]
+        else:
+            print("[toobusy Z-Image Turbo] Both conditioning overrides connected and no LoRA active — skipping the CLIP loader.")
+            clip = None
 
         if vae_override is not None:
             print("[toobusy Z-Image Turbo] Using external VAE override. Internal VAE loader ignored.")
@@ -335,29 +375,42 @@ class ToobusyZImageTurbo:
         # controlnet — for swapping LoRAs in a second pass.
         model_clean = model
 
-        lora_slots = max(0, min(MAX_LORA_SLOTS, int(lora_slots)))
-        for slot in range(1, lora_slots + 1):
-            enabled = lora_kwargs.get(f"lora_{slot}_enable", False)
-            lora_name = lora_kwargs.get(f"lora_{slot}_name", "None")
-            lora_strength = lora_kwargs.get(f"lora_{slot}_strength", 1.0)
-            if enabled and lora_name != "None":
-                model, clip = _call_node(
-                    "LoraLoader",
-                    model=model,
-                    clip=clip,
-                    lora_name=lora_name,
-                    strength_model=lora_strength,
-                    strength_clip=lora_strength,
-                )
+        for lora_name, lora_strength in active_loras:
+            model, clip = _call_node(
+                "LoraLoader",
+                model=model,
+                clip=clip,
+                lora_name=lora_name,
+                strength_model=lora_strength,
+                strength_clip=lora_strength,
+            )
 
         model = _call_node("ModelSamplingAuraFlow", model=model, shift=aura_shift)[0]
-        positive_cond = _call_node("CLIPTextEncode", clip=clip, text=positive)[0]
-        negative_cond = _call_node("CLIPTextEncode", clip=clip, text=negative)[0]
+        if positive_override is not None:
+            print("[toobusy Z-Image Turbo] Using external positive conditioning. Prompt text ignored.")
+            positive_cond = positive_override
+        else:
+            positive_cond = _call_node("CLIPTextEncode", clip=clip, text=positive)[0]
+        if negative_override is not None:
+            print("[toobusy Z-Image Turbo] Using external negative conditioning. Negative text ignored.")
+            negative_cond = negative_override
+        else:
+            negative_cond = _call_node("CLIPTextEncode", clip=clip, text=negative)[0]
 
-        # Latent source. A connected image auto-switches the node to img2img:
-        # the image is VAE-encoded into the starting latent and 'denoise' acts
-        # as the change strength. Otherwise we start from an empty latent (t2i).
-        if image is not None:
+        # Latent source priority: external latent > connected image (img2img)
+        # > empty latent (t2i). With a latent or image, 'denoise' acts as the
+        # change strength.
+        if latent_override is not None:
+            if image is not None:
+                print("[toobusy Z-Image Turbo] Both latent_override and image connected — the latent wins, image input ignored.")
+            latent_image = latent_override
+            latent_w, latent_h = _latent_dims(latent_override)
+            if latent_w > 0 and latent_h > 0:
+                width, height = latent_w, latent_h
+            else:
+                width, height = target_w, target_h
+            print(f"[toobusy Z-Image Turbo] External latent input -> {width}x{height} (denoise = strength).")
+        elif image is not None:
             explicit_size = int(width) > 0 and int(height) > 0
             if explicit_size:
                 print(f"[toobusy Z-Image Turbo] Image input detected -> img2img. Scaling source to {target_w}x{target_h} (denoise = strength).")


### PR DESCRIPTION
Operator feedback after the passthrough outputs landed: the node
should accept what it exports. New advanced-gated optional inputs:

- positive_override / negative_override (CONDITIONING): connected =
  the matching prompt text is ignored. With both connected and no
  active LoRA the internal CLIP loader is skipped entirely (clip
  passthrough is None then).
- latent_override (LATENT): wins over the image input and the empty
  latent; width/height follow the latent dims and denoise acts as
  the change strength. This closes the hires-fix loop as Z-Image ->
  toobusy Hires Upscale -> Z-Image (latent in) with no external
  sampler.

The resolution readout shows the latent-input state, and the new
sockets join the advanced override gating (never dropped while
connected). LoRA activation is now collected up front so the CLIP
need is known before loading.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
