### PR TITLE
Fix DWPose KeyError: unwrap {ui, result} dict returns in _call_node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### Fixed
+- **`toobusy ZIT ControlNet` pose 전처리 KeyError 수정**: 공용 `_call_node`가
+  미리보기 UI가 있는 노드의 `{"ui": ..., "result": (...)}` 반환을 튜플로 풀지
+  않아 DWPose(controlnet_aux) 호출 후 `result[0]`이 `KeyError: 0`으로 터졌습니다.
+  헬퍼가 이제 dict-result와 V3 NodeOutput을 모두 출력 튜플로 정규화합니다(미리보기
+  출력이 있는 모든 코어/커스텀 노드에 적용).
 - **`toobusy Flux2 Klein` 실행 불가 버그 수정**(검수): 레퍼런스 컨디셔닝이 백엔드에
   존재하지 않는 서브그래프 UUID 클래스를 호출하고 있었음 → 원본 워크플로우의 실제
   체인(`ImageScaleToTotalPixels`(lanczos·1MP) → `VAEEncode` → `ReferenceLatent`)

--- a/ltx23_compact_sampler_node/ltx23_compact_sampler.py
+++ b/ltx23_compact_sampler_node/ltx23_compact_sampler.py
@@ -101,10 +101,25 @@ def _call_node(class_name, **kwargs):
 
     kwargs = _fill_input_defaults(cls, dict(kwargs), params, has_var_keyword)
     if has_var_keyword or params is None:
-        return fn(**kwargs)
+        return _unwrap_result(fn(**kwargs))
 
     filtered = {key: value for key, value in kwargs.items() if key in params}
-    return fn(**filtered)
+    return _unwrap_result(fn(**filtered))
+
+
+def _unwrap_result(result):
+    """Normalize a node's return into the plain output tuple.
+
+    Nodes with a preview/UI (e.g. comfyui_controlnet_aux preprocessors,
+    PreviewImage) return ``{"ui": {...}, "result": (...)}`` instead of a bare
+    tuple — indexing that dict with ``[0]`` raised ``KeyError: 0``. V3
+    io.ComfyNode classes return a NodeOutput whose values live in ``.args``."""
+    args = getattr(result, "args", None)
+    if args is not None:
+        return tuple(args)
+    if isinstance(result, dict):
+        return tuple(result.get("result", ()))
+    return result
 
 
 def _sampler_names():

--- a/tests/test_call_node_helper.py
+++ b/tests/test_call_node_helper.py
@@ -130,6 +130,34 @@ def test_v3_node_unknown_kwargs_filtered():
     assert result[0] == "img"
 
 
+class _PreviewNode:
+    """A node with a preview UI returns {"ui": ..., "result": (...)} instead of
+    a bare tuple — the shape that crashed ZIT ControlNet's DWPose call with
+    KeyError: 0 when the caller did result[0]."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"image": ("IMAGE",)}}
+
+    FUNCTION = "run"
+
+    def run(self, image):
+        return {"ui": {"images": ["preview.png"]}, "result": (f"processed-{image}",)}
+
+
+def test_dict_result_with_ui_is_unwrapped():
+    _NODE_REGISTRY["Preview"] = _PreviewNode
+    result = _mod._call_node("Preview", image="img")
+    # Must be the result tuple, so result[0] works (not the dict -> KeyError: 0).
+    assert result[0] == "processed-img"
+
+
+def test_plain_tuple_return_is_unchanged():
+    _NODE_REGISTRY["Classic"] = _ClassicNode
+    result = _mod._call_node("Classic", image="img", method="lanczos")
+    assert isinstance(result, tuple) and result[0] == "img"
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
Operator field crash: ZIT ControlNet pose path ran DWPose fine, then
raised KeyError: 0. comfyui_controlnet_aux preprocessors (and any node
with a preview) return {ui: {...}, result: (...)} instead of a bare
tuple, and _call_node passed that straight through, so the caller's
result[0] indexed the dict. _call_node now normalizes both dict-result
returns and V3 NodeOutput into the plain output tuple (the SCAIL
_call_core already did this; the shared helper now matches). Covered by
a preview-node test reproducing the exact shape.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
