### PR TITLE
Simplify Flux2 Klein references to a single +/- count

### DIFF
--- a/flux2_klein_node/flux2_klein.py
+++ b/flux2_klein_node/flux2_klein.py
@@ -180,9 +180,9 @@ class ToobusyFlux2Klein:
         }
 
         required = base["required"]
-        for slot in range(1, MAX_REFERENCE_SLOTS + 1):
-            required[f"reference_{slot}_enable"] = ("BOOLEAN", {"default": True})
-
+        # References are driven by `reference_slots` alone (JS +/- buttons show
+        # that many image sockets); a slot is applied when its image is
+        # connected. No per-slot enable flags.
         for slot in range(1, MAX_LORA_SLOTS + 1):
             required[f"lora_{slot}_enable"] = ("BOOLEAN", {"default": False})
             required[f"lora_{slot}_name"] = (lora_names, {"default": "None"})
@@ -284,13 +284,9 @@ class ToobusyFlux2Klein:
         first_active_image = None
 
         for slot in range(1, reference_slots + 1):
-            enabled = bool(slot_kwargs.get(f"reference_{slot}_enable", True))
             image = references.get(slot)
-            if not enabled:
-                print(f"[toobusy Flux2 Klein] Reference #{slot} disabled.")
-                continue
             if image is None:
-                print(f"[toobusy Flux2 Klein] Reference #{slot} enabled but no IMAGE connected; skipped.")
+                print(f"[toobusy Flux2 Klein] Reference #{slot} has no IMAGE connected; skipped.")
                 continue
             if first_active_image is None:
                 first_active_image = image

--- a/js/toobusy_flux2_klein.js
+++ b/js/toobusy_flux2_klein.js
@@ -228,13 +228,6 @@ function updateLoraSlots(node) {
     }
 }
 
-function referenceSlotWidgets(node, slot) {
-    return [
-        findWidget(node, `reference_${slot}_enable`),
-        node[`_toobusyRemoveReference${slot}`],
-    ];
-}
-
 function setInputVisible(node, name, type, visible) {
     const idx = node.inputs ? node.inputs.findIndex((i) => i.name === name) : -1;
     const exists = idx >= 0;
@@ -255,31 +248,29 @@ function updateReferenceReadout(node) {
     const readout = findWidget(node, "klein_reference_readout");
     if (!readout) return;
     const count = activeSlotCount(node, "reference_slots", MAX_REFERENCE_SLOTS);
-    readout.value = `Klein references: #1 -> #2 -> #3 (${count}/${MAX_REFERENCE_SLOTS} visible)`;
+    readout.value = count > 0
+        ? `References: ${count} — connect images to the slots above`
+        : "References: 0 (prompt only)";
     node.setDirtyCanvas?.(true, true);
 }
 
+// Reference count is driven purely by reference_slots: that many image input
+// sockets are shown, and a + / − pair changes the count. No per-slot enable
+// or disable — connect an image to a slot to use it.
 function updateReferenceSlots(node) {
     const count = activeSlotCount(node, "reference_slots", MAX_REFERENCE_SLOTS);
     for (let slot = 1; slot <= MAX_REFERENCE_SLOTS; slot += 1) {
-        const visible = slot <= count;
-        setInputVisible(node, `reference_${slot}_image`, "IMAGE", visible);
-        for (const widget of referenceSlotWidgets(node, slot)) setWidgetVisible(node, widget, visible);
+        setInputVisible(node, `reference_${slot}_image`, "IMAGE", slot <= count);
     }
-    setWidgetVisible(node, node._toobusyAddReferenceBtn, true);
     if (node._toobusyAddReferenceBtn) {
-        node._toobusyAddReferenceBtn.name = count >= MAX_REFERENCE_SLOTS ? "Reference slots full" : "Add reference slot";
+        node._toobusyAddReferenceBtn.name = count >= MAX_REFERENCE_SLOTS
+            ? `References full (${MAX_REFERENCE_SLOTS})`
+            : "＋ Add reference";
+    }
+    if (node._toobusyRemoveReferenceBtn) {
+        node._toobusyRemoveReferenceBtn.name = count <= 0 ? "No references" : "✕ Remove reference";
     }
     updateReferenceReadout(node);
-}
-
-function removeReferenceSlot(node, slot) {
-    const widget = findWidget(node, `reference_${slot}_enable`);
-    if (widget) {
-        widget.value = false;
-        widget.callback?.(false);
-    }
-    updateReferenceSlots(node);
 }
 
 function applyAdvanced(node) {
@@ -316,23 +307,16 @@ app.registerExtension({
                 };
             }
 
-            for (let slot = 1; slot <= MAX_REFERENCE_SLOTS; slot += 1) {
-                const button = this.addWidget("button", `Disable reference ${slot}`, "disable", () => {
-                    removeReferenceSlot(this, slot);
-                }, { serialize: false });
-                this[`_toobusyRemoveReference${slot}`] = button;
-                const widgets = this.widgets;
-                const fromIndex = widgets.indexOf(button);
-                if (fromIndex >= 0) widgets.splice(fromIndex, 1);
-                const enable = findWidget(this, `reference_${slot}_enable`);
-                const insertAt = enable ? widgets.indexOf(enable) + 1 : widgets.length;
-                widgets.splice(insertAt, 0, button);
-            }
-
-            this._toobusyAddReferenceBtn = this.addWidget("button", "Add reference slot", "add", () => {
+            this._toobusyAddReferenceBtn = this.addWidget("button", "＋ Add reference", "add", () => {
                 const count = activeSlotCount(this, "reference_slots", MAX_REFERENCE_SLOTS);
                 if (count >= MAX_REFERENCE_SLOTS) return;
                 setActiveSlotCount(this, "reference_slots", count + 1, MAX_REFERENCE_SLOTS, updateReferenceSlots);
+            }, { serialize: false });
+
+            this._toobusyRemoveReferenceBtn = this.addWidget("button", "✕ Remove reference", "remove", () => {
+                const count = activeSlotCount(this, "reference_slots", MAX_REFERENCE_SLOTS);
+                if (count <= 0) return;
+                setActiveSlotCount(this, "reference_slots", count - 1, MAX_REFERENCE_SLOTS, updateReferenceSlots);
             }, { serialize: false });
 
             const loraSlotWidget = findWidget(this, "lora_slots");

--- a/tests/test_flux2_klein.py
+++ b/tests/test_flux2_klein.py
@@ -81,7 +81,6 @@ def _generate(**overrides):
         model_name="m", clip_name="c", vae_name="v", positive="p",
         ratio_preset="1:1", megapixels=1.0, divisible_by=32, batch_size=1,
         seed=1, steps=4, sampler_name="euler", lora_slots=0, reference_slots=3,
-        reference_1_enable=True, reference_2_enable=True, reference_3_enable=True,
     )
     kwargs.update(overrides)
     return _mod.ToobusyFlux2Klein().generate(**kwargs)
@@ -106,9 +105,16 @@ def test_references_use_real_core_chain():
     assert all("-" not in nt or nt.count("-") < 4 for nt, _ in _CALLS)
 
 
-def test_disabled_or_missing_references_are_skipped():
-    _generate(reference_1_image=_FakeImage(512, 512), reference_1_enable=False)
-    assert not _called("ReferenceLatent")
+def test_references_beyond_count_are_not_applied():
+    # reference_slots=1 -> only slot 1 is applied even if more images are wired.
+    _generate(reference_slots=1, reference_1_image=_FakeImage(512, 512), reference_2_image=_FakeImage(256, 256))
+    assert len(_called("ReferenceLatent")) == 1
+
+
+def test_unconnected_slots_are_skipped():
+    # count covers 2 slots but only slot 2 has an image -> one reference applied.
+    _generate(reference_slots=2, reference_2_image=_FakeImage(512, 512))
+    assert len(_called("ReferenceLatent")) == 1
 
 
 def test_internal_clip_loader_uses_flux2_type():


### PR DESCRIPTION
Operator called the reference UI a mess: per-slot enable toggles, a
separate "Disable reference" button per slot, and the reference_slots
count all overlapped, "Reference slots full" was opaque, and the image
sockets didn't track the count.

References are now driven by reference_slots alone: that many image
input sockets show, and a "+ Add reference" / "x Remove reference" pair
changes the count (the Wan SCAIL extend-segment pattern). The per-slot
enable flags and the disable buttons are gone - connect an image to a
shown slot to use it; slots beyond the count or without an image are
skipped. Python drops the enable flags and applies slots 1..count that
have an image connected.

Flux2 Klein is an unreleased prototype, so the widget-layout change is
fine. Tests updated for the count-only behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
