### PR TITLE
Note Gemma-only generation in Load CLIP help (doc-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,12 @@ safetensors든 `.gguf`든 **한 노드로 텍스트 인코더를 로드**하면�
 인핸서**로 쓸 때. GGUF 파일은 ComfyUI-GGUF가 설치돼 있어야 로드되고, 없으면 명확한
 안내 메시지를 냅니다.
 
+> ⚠️ **프롬프트 인핸서로 쓸 땐 Gemma 계열 인코더가 필요합니다.** ComfyUI는 파일
+> 아키텍처로 래퍼를 자동 판별하는데, **Gemma 계열만 `generate()`를 노출**합니다.
+> Llama 계열(Dolphin 등)은 이 노드로 **로드는 되지만** encode 전용 래퍼로 잡혀
+> Text Generate에서 동작하지 않습니다. 무검열 프롬프트 확장이 목적이면 Gemma 3
+> (4B/12B/27B) abliterated GGUF를 쓰세요. (`type` 드롭다운은 LLM 파일에선 무시됨.)
+
 ### toobusy Hires Upscale
 
 카테고리:

--- a/load_clip_node/load_clip.py
+++ b/load_clip_node/load_clip.py
@@ -161,12 +161,24 @@ class ToobusyLoadClip:
     """A text-encoder loader that grows the model to fit the file, so custom /
     added-token LLM encoders (safetensors or GGUF) load with every token kept."""
 
+    DESCRIPTION = (
+        "Loads safetensors / .gguf text encoders and grows the model to fit "
+        "added-token fine-tunes (no token loss).\n\n"
+        "For an LLM prompt enhancer (-> Text Generate): the encoder must be a "
+        "GENERATION-capable family. ComfyUI auto-detects the architecture from "
+        "the file, and only Gemma-family encoders expose generate(). A Llama "
+        "checkpoint (Dolphin etc.) LOADS but routes to an encode-only wrapper "
+        "with no generate(), so Text Generate fails. Use a Gemma 3 (4B/12B/27B) "
+        "encoder — e.g. an abliterated GGUF for uncensored prompt expansion. "
+        "The `type` dropdown is ignored for LLM files (architecture wins)."
+    )
+
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "clip_name": (_clip_name_options(), {"tooltip": "Text encoder file (safetensors or .gguf). Both folders are merged here."}),
-                "type": (_clip_type_options(), {"default": "lumina2", "tooltip": "Text-encoder architecture (same list as the core CLIPLoader)."}),
+                "clip_name": (_clip_name_options(), {"tooltip": "Text encoder file (safetensors or .gguf). Both folders are merged here. For an LLM prompt enhancer (Text Generate), use a Gemma-family encoder — Llama/Dolphin loads but can't generate."}),
+                "type": (_clip_type_options(), {"default": "lumina2", "tooltip": "Text-encoder architecture (same list as the core CLIPLoader). Ignored for LLM files — ComfyUI auto-detects from the checkpoint."}),
             },
             "optional": {
                 "fit_model_to_file": (


### PR DESCRIPTION
Doc-only: the loader makes a Llama/Dolphin encoder LOAD, but ComfyUI
routes Llama text encoders to an encode-only wrapper with no
generate(), so a Text Generate prompt-enhancer chain needs a
Gemma-family encoder. Surfaced via the node DESCRIPTION, the
clip_name/type tooltips, and the README so users do not repeat the
Dolphin dead-end. No logic change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
