### PR TITLE
Raise Flux2 Klein references to 5 (count-driven sockets)

### DIFF
--- a/flux2_klein_node/flux2_klein.py
+++ b/flux2_klein_node/flux2_klein.py
@@ -19,7 +19,7 @@ RATIO_PRESETS = {
 }
 
 MAX_LORA_SLOTS = 5
-MAX_REFERENCE_SLOTS = 3
+MAX_REFERENCE_SLOTS = 5
 
 
 def _folder_list(kind, fallback):
@@ -170,19 +170,23 @@ class ToobusyFlux2Klein:
                     {"default": 0, "min": 0, "max": 8192, "step": 8,
                      "tooltip": "0 = use reference #1 size when connected; otherwise ratio_preset + megapixels. Set width AND height > 0 for manual size."},
                 ),
-                "reference_1_image": ("IMAGE", {"tooltip": "Reference #1. In the source workflow this image also drives the default width/height."}),
-                "reference_2_image": ("IMAGE", {"tooltip": "Reference #2. Applied after reference #1 in the conditioning chain."}),
-                "reference_3_image": ("IMAGE", {"tooltip": "Reference #3. Applied last in the Klein conditioning chain."}),
                 "model_override": ("MODEL",),
                 "clip_override": ("CLIP",),
                 "vae_override": ("VAE",),
             },
         }
 
+        optional = base["optional"]
+        # Reference image sockets are generated up to MAX_REFERENCE_SLOTS; the
+        # JS +/- buttons show `reference_slots` of them. A slot is applied when
+        # its image is connected. No per-slot enable flags.
+        for slot in range(1, MAX_REFERENCE_SLOTS + 1):
+            optional[f"reference_{slot}_image"] = (
+                "IMAGE",
+                {"tooltip": f"Reference #{slot}. Applied in order in the Klein conditioning chain (reference #1 also drives the default size)."},
+            )
+
         required = base["required"]
-        # References are driven by `reference_slots` alone (JS +/- buttons show
-        # that many image sockets); a slot is applied when its image is
-        # connected. No per-slot enable flags.
         for slot in range(1, MAX_LORA_SLOTS + 1):
             required[f"lora_{slot}_enable"] = ("BOOLEAN", {"default": False})
             required[f"lora_{slot}_name"] = (lora_names, {"default": "None"})
@@ -221,9 +225,6 @@ class ToobusyFlux2Klein:
         reference_slots,
         width=0,
         height=0,
-        reference_1_image=None,
-        reference_2_image=None,
-        reference_3_image=None,
         model_override=None,
         clip_override=None,
         vae_override=None,
@@ -277,9 +278,8 @@ class ToobusyFlux2Klein:
         # ReferenceLatent, chained on the conditioning — all core nodes.
         reference_slots = max(0, min(MAX_REFERENCE_SLOTS, int(reference_slots)))
         references = {
-            1: reference_1_image,
-            2: reference_2_image,
-            3: reference_3_image,
+            slot: slot_kwargs.get(f"reference_{slot}_image")
+            for slot in range(1, MAX_REFERENCE_SLOTS + 1)
         }
         first_active_image = None
 

--- a/js/toobusy_flux2_klein.js
+++ b/js/toobusy_flux2_klein.js
@@ -1,7 +1,7 @@
 import { app } from "../../scripts/app.js";
 
 const MAX_LORA_SLOTS = 5;
-const MAX_REFERENCE_SLOTS = 3;
+const MAX_REFERENCE_SLOTS = 5;
 const ACCENT = "#7fc8ff";
 
 const ADVANCED_WIDGETS = [

--- a/tests/test_flux2_klein.py
+++ b/tests/test_flux2_klein.py
@@ -117,6 +117,17 @@ def test_unconnected_slots_are_skipped():
     assert len(_called("ReferenceLatent")) == 1
 
 
+def test_supports_up_to_five_references():
+    assert _mod.MAX_REFERENCE_SLOTS == 5
+    images = {f"reference_{i}_image": _FakeImage(512, 512) for i in range(1, 6)}
+    _generate(reference_slots=5, **images)
+    assert len(_called("ReferenceLatent")) == 5
+    # All five image sockets are exposed as optional inputs.
+    optional = _mod.ToobusyFlux2Klein.INPUT_TYPES()["optional"]
+    for i in range(1, 6):
+        assert optional[f"reference_{i}_image"][0] == "IMAGE"
+
+
 def test_internal_clip_loader_uses_flux2_type():
     _generate()
     clips = _called("CLIPLoader")


### PR DESCRIPTION
The 3-reference cap just mirrored the source workflow; the core
ReferenceLatent chains references with append=True and has no limit
("chain multiple to set multiple reference images"). Bump
MAX_REFERENCE_SLOTS to 5 and generate the reference_N_image sockets in
a loop instead of hardcoding three, so the count, the +/- buttons, and
the sockets all follow one constant. generate() collects the images
from slot_kwargs rather than fixed params. Default count stays 3.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
