### PR TITLE
Make Flux2 Klein output size source explicit (size_mode + readout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
   위임(`.gguf`는 ComfyUI-GGUF, 나머지는 코어 CLIPLoader)해 toobusy에 GGUF 의존성을
   더하지 않습니다. 로컬 LLM 프롬프트 인핸서 체인에 유용.
 
+### Changed
+- `toobusy Flux2 Klein`에 **`size_mode`**(from reference / ratio + megapixels /
+  manual)와 **사이즈 readout**을 추가했습니다. 레퍼런스 #1이 ratio/megapixels를
+  조용히 덮어쓰던 동작이 이제 명시적이고(기본 `from reference`라 동작 불변), readout이
+  실제 출력 크기·소스를 보여줘 "1:1@1MP로 설정했는데 레퍼런스 크기로 나오는" 혼란을
+  없앱니다. 레퍼런스 연결 상태에서도 `ratio + megapixels`로 강제 가능. 레퍼런스
+  슬롯 최대 3→5로 확대. (운영자 피드백)
+
 ### Fixed
 - **`toobusy ZIT ControlNet` pose 전처리 KeyError 수정**: 공용 `_call_node`가
   미리보기 UI가 있는 노드의 `{"ui": ..., "result": (...)}` 반환을 튜플로 풀지

--- a/flux2_klein_node/flux2_klein.py
+++ b/flux2_klein_node/flux2_klein.py
@@ -141,6 +141,13 @@ class ToobusyFlux2Klein:
                         "multiline": True,
                     },
                 ),
+                "size_mode": (
+                    ["from reference", "ratio + megapixels", "manual"],
+                    {
+                        "default": "from reference",
+                        "tooltip": "Where the output size comes from. 'from reference' = match reference #1 (Klein default — ratio/megapixels are ignored while a reference is connected); 'ratio + megapixels' = use the ratio_preset + megapixels below; 'manual' = use width/height.",
+                    },
+                ),
                 "ratio_preset": (list(RATIO_PRESETS.keys()), {"default": "1:1"}),
                 "megapixels": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 4.0, "step": 0.05}),
                 "divisible_by": ("INT", {"default": 32, "min": 8, "max": 128, "step": 8}),
@@ -214,6 +221,7 @@ class ToobusyFlux2Klein:
         clip_name,
         vae_name,
         positive,
+        size_mode,
         ratio_preset,
         megapixels,
         divisible_by,
@@ -305,13 +313,31 @@ class ToobusyFlux2Klein:
             )[0]
             print(f"[toobusy Flux2 Klein] Reference #{slot} applied.")
 
+        # Output size comes from one of three explicit sources (size_mode), so
+        # a connected reference never silently overrides the ratio/megapixels.
+        size_mode = str(size_mode)
+        ratio_size = _resolution_from_megapixels(ratio_preset, megapixels, divisible_by)
+        manual_size = None
         if int(width) > 0 and int(height) > 0:
-            target_w = _round_to(int(width), divisible_by)
-            target_h = _round_to(int(height), divisible_by)
-        else:
-            target_w, target_h = _image_dims(first_active_image) if first_active_image is not None else (0, 0)
-            if target_w <= 0 or target_h <= 0:
-                target_w, target_h = _resolution_from_megapixels(ratio_preset, megapixels, divisible_by)
+            manual_size = (_round_to(int(width), divisible_by), _round_to(int(height), divisible_by))
+
+        if size_mode == "manual":
+            if manual_size is not None:
+                target_w, target_h = manual_size
+            else:
+                target_w, target_h = ratio_size
+                print("[toobusy Flux2 Klein] size_mode=manual but width/height are 0 — using ratio + megapixels.")
+        elif size_mode == "ratio + megapixels":
+            target_w, target_h = ratio_size
+        else:  # "from reference"
+            ref_w, ref_h = _image_dims(first_active_image) if first_active_image is not None else (0, 0)
+            if ref_w > 0 and ref_h > 0:
+                target_w, target_h = ref_w, ref_h
+            else:
+                target_w, target_h = ratio_size
+                print("[toobusy Flux2 Klein] size_mode=from reference but no reference connected — using ratio + megapixels.")
+
+        print(f"[toobusy Flux2 Klein] Output size {target_w}x{target_h} (size_mode: {size_mode}).")
 
         noise = _call_node("RandomNoise", noise_seed=seed)[0]
         guider = _call_node("BasicGuider", model=model, conditioning=conditioning)[0]

--- a/js/toobusy_flux2_klein.js
+++ b/js/toobusy_flux2_klein.js
@@ -4,6 +4,25 @@ const MAX_LORA_SLOTS = 5;
 const MAX_REFERENCE_SLOTS = 5;
 const ACCENT = "#7fc8ff";
 
+// Mirror of flux2_klein.py RATIO_PRESETS / _resolution_from_megapixels so the
+// node can preview the size it will generate for the ratio/manual modes.
+const RATIO_PRESETS = {
+    "1:1": [1, 1], "16:9": [16, 9], "9:16": [9, 16], "4:3": [4, 3],
+    "3:4": [3, 4], "3:2": [3, 2], "2:3": [2, 3],
+};
+
+function roundToMultiple(value, divisor) {
+    const d = Math.max(1, Math.round(divisor) || 1);
+    return Math.max(d, Math.round(value / d) * d);
+}
+
+function resolutionFromMegapixels(ratioPreset, megapixels, divisibleBy) {
+    const [rw, rh] = RATIO_PRESETS[ratioPreset] || RATIO_PRESETS["1:1"];
+    const pixels = Math.max(0.01, Number(megapixels) || 0) * 1_000_000;
+    const scale = Math.sqrt(pixels / (rw * rh));
+    return [roundToMultiple(rw * scale, divisibleBy), roundToMultiple(rh * scale, divisibleBy)];
+}
+
 const ADVANCED_WIDGETS = [
     "megapixels",
     "divisible_by",
@@ -142,10 +161,10 @@ function drawInfoBadge(node, ctx) {
     ctx.restore();
 }
 
-function makeReadoutWidget() {
+function makeReadoutWidget(name = "klein_reference_readout") {
     return {
         type: "toobusy_klein_readout",
-        name: "klein_reference_readout",
+        name,
         value: "",
         options: { serialize: false },
         serialize: false,
@@ -254,6 +273,49 @@ function updateReferenceReadout(node) {
     node.setDirtyCanvas?.(true, true);
 }
 
+function reference1Connected(node) {
+    const input = node.inputs?.find((i) => i.name === "reference_1_image");
+    return !!(input && input.link != null);
+}
+
+// Show where the output size actually comes from, so a connected reference
+// silently overriding ratio/megapixels never surprises the user again.
+function updateSizeReadout(node) {
+    const readout = findWidget(node, "klein_size_readout");
+    if (!readout) return;
+    const mode = String(findWidget(node, "size_mode")?.value || "from reference");
+    const ratio = String(findWidget(node, "ratio_preset")?.value || "1:1");
+    const mp = Number(findWidget(node, "megapixels")?.value ?? 1);
+    const div = Number(findWidget(node, "divisible_by")?.value ?? 32);
+    const w = Number(findWidget(node, "width")?.value ?? 0);
+    const h = Number(findWidget(node, "height")?.value ?? 0);
+    const [rw, rh] = resolutionFromMegapixels(ratio, mp, div);
+
+    if (mode === "manual") {
+        readout.value = w > 0 && h > 0
+            ? `Size: ${roundToMultiple(w, div)} x ${roundToMultiple(h, div)} (manual)`
+            : `Size: ${rw} x ${rh} (manual w/h are 0 -> ratio)`;
+    } else if (mode === "ratio + megapixels") {
+        readout.value = `Size: ${rw} x ${rh} (${ratio} @ ${mp.toFixed(2)}MP)`;
+    } else {
+        // from reference
+        readout.value = reference1Connected(node)
+            ? "Size: follows reference #1 (ratio/MP ignored)"
+            : `Size: ${rw} x ${rh} (no reference -> ratio @ ${mp.toFixed(2)}MP)`;
+    }
+    node.setDirtyCanvas?.(true, true);
+}
+
+function hookSizeReadout(node, name) {
+    const widget = findWidget(node, name);
+    if (!widget) return;
+    const original = widget.callback;
+    widget.callback = (...args) => {
+        original?.apply(widget, args);
+        updateSizeReadout(node);
+    };
+}
+
 // Reference count is driven purely by reference_slots: that many image input
 // sockets are shown, and a + / − pair changes the count. No per-slot enable
 // or disable — connect an image to a slot to use it.
@@ -292,6 +354,13 @@ app.registerExtension({
         const onNodeCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             onNodeCreated?.apply(this, arguments);
+
+            const sizeReadout = makeReadoutWidget("klein_size_readout");
+            if (this.addCustomWidget) this.addCustomWidget(sizeReadout);
+            else (this.widgets = this.widgets || []).push(sizeReadout);
+            for (const name of ["size_mode", "ratio_preset", "megapixels", "divisible_by", "width", "height"]) {
+                hookSizeReadout(this, name);
+            }
 
             const readout = makeReadoutWidget();
             if (this.addCustomWidget) this.addCustomWidget(readout);
@@ -355,12 +424,22 @@ app.registerExtension({
             }, { serialize: false });
 
             applyAdvanced(this);
+            updateSizeReadout(this);
         };
 
         const onConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
             onConfigure?.apply(this, arguments);
             applyAdvanced(this);
+            updateSizeReadout(this);
+        };
+
+        // Connecting/disconnecting reference #1 flips the "from reference" size.
+        const onConnectionsChange = nodeType.prototype.onConnectionsChange;
+        nodeType.prototype.onConnectionsChange = function () {
+            const result = onConnectionsChange?.apply(this, arguments);
+            updateSizeReadout(this);
+            return result;
         };
 
         const onDrawForeground = nodeType.prototype.onDrawForeground;

--- a/tests/test_flux2_klein.py
+++ b/tests/test_flux2_klein.py
@@ -79,6 +79,7 @@ def _generate(**overrides):
     _CALLS.clear()
     kwargs = dict(
         model_name="m", clip_name="c", vae_name="v", positive="p",
+        size_mode="from reference",
         ratio_preset="1:1", megapixels=1.0, divisible_by=32, batch_size=1,
         seed=1, steps=4, sampler_name="euler", lora_slots=0, reference_slots=3,
     )
@@ -134,16 +135,31 @@ def test_internal_clip_loader_uses_flux2_type():
     assert clips and clips[0]["type"] == "flux2"
 
 
-def test_size_follows_first_active_reference():
-    _generate(reference_1_image=_FakeImage(510, 770))
+def test_from_reference_uses_reference_size():
+    _generate(size_mode="from reference", reference_1_image=_FakeImage(510, 770))
     latents = _called("EmptyFlux2LatentImage")
     assert latents and (latents[0]["width"], latents[0]["height"]) == (768, 504)
 
 
-def test_manual_size_wins_over_reference():
-    _generate(reference_1_image=_FakeImage(512, 512), width=768, height=1280)
+def test_ratio_megapixels_mode_ignores_connected_reference():
+    # The operator's case: 1:1 @ 1MP must win even with a reference connected.
+    _generate(size_mode="ratio + megapixels", ratio_preset="1:1", megapixels=1.0,
+              reference_1_image=_FakeImage(510, 770))
+    latents = _called("EmptyFlux2LatentImage")
+    # 1:1 @ 1MP, divisible_by 32 -> 992 x 992
+    assert latents and (latents[0]["width"], latents[0]["height"]) == (992, 992)
+
+
+def test_manual_mode_uses_width_height():
+    _generate(size_mode="manual", reference_1_image=_FakeImage(512, 512), width=768, height=1280)
     latents = _called("EmptyFlux2LatentImage")
     assert latents and (latents[0]["width"], latents[0]["height"]) == (768, 1280)
+
+
+def test_from_reference_without_reference_falls_back_to_ratio():
+    _generate(size_mode="from reference", ratio_preset="1:1", megapixels=1.0)
+    latents = _called("EmptyFlux2LatentImage")
+    assert latents and (latents[0]["width"], latents[0]["height"]) == (992, 992)
 
 
 def test_passthrough_outputs_and_slot_order():


### PR DESCRIPTION
Operator set 1:1 @ 1MP but the output came out at reference #1's size
with no indication why. The size priority silently let a connected
reference #1 override ratio_preset/megapixels.

Add a size_mode dropdown (from reference / ratio + megapixels / manual)
so the source is explicit, plus a size readout that shows the resolved
size and which source decides it (and flips when reference #1 is
connected/disconnected). Default stays "from reference" so existing
behavior is unchanged, but it is now visible and the operator can force
ratio + megapixels even with a reference connected.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
