### PR TITLE
Add color_anchor to SCAIL Extend Sampler (stop cumulative color fade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   더하지 않습니다. 로컬 LLM 프롬프트 인핸서 체인에 유용.
 
 ### Changed
+- `toobusy Wan SCAIL Extend Sampler`에 **`color_anchor`**(first chunk / previous
+  chunk) 옵션 추가. 청크 확장의 누적 색빠짐(VAE 왕복으로 청크마다 채도가 조금씩
+  깎임)을 막기 위해, color_match가 **첫 청크의 마지막 프레임을 고정 앵커**로
+  삼도록 기본값을 `first chunk`로 했습니다. `previous chunk`는 이전 청크 기준
+  (이음새 가장 매끄럽지만 드리프트를 따라감). (운영자 피드백)
 - `toobusy Flux2 Klein`에 **`size_mode`**(from reference / ratio + megapixels /
   manual)와 **사이즈 readout**을 추가했습니다. 레퍼런스 #1이 ratio/megapixels를
   조용히 덮어쓰던 동작이 이제 명시적이고(기본 `from reference`라 동작 불변), readout이

--- a/js/toobusy_wan_scail_extend_sampler.js
+++ b/js/toobusy_wan_scail_extend_sampler.js
@@ -13,6 +13,7 @@ const ADVANCED_WIDGETS = [
     "shift",
     "previous_frame_count",
     "color_match",
+    "color_anchor",
     "pose_strength",
     "pose_start",
     "pose_end",

--- a/tests/test_wan_scail_extend_sampler.py
+++ b/tests/test_wan_scail_extend_sampler.py
@@ -116,7 +116,8 @@ def _generate(**overrides):
         positive="p", negative="n", width=512, height=896,
         base_frames=65, extend_segments=0, seed=7, steps=6, cfg=1.0,
         sampler_name="euler", scheduler="simple", shift=5.0,
-        previous_frame_count=5, color_match=False, replacement_mode=False,
+        previous_frame_count=5, color_match=False, color_anchor="first chunk",
+        replacement_mode=False,
         pose_strength=1.0, pose_start=0.0, pose_end=1.0, clip_vision_crop="none",
     )
     kwargs.update(overrides)
@@ -241,13 +242,89 @@ def test_old_core_without_scail2_inputs_fails_clearly():
             positive="", negative="", width=512, height=896, base_frames=65,
             extend_segments=0, seed=1, steps=6, cfg=1.0, sampler_name="euler",
             scheduler="simple", shift=5.0, previous_frame_count=5,
-            color_match=False, replacement_mode=False, pose_strength=1.0,
-            pose_start=0.0, pose_end=1.0, clip_vision_crop="none",
+            color_match=False, color_anchor="first chunk", replacement_mode=False,
+            pose_strength=1.0, pose_start=0.0, pose_end=1.0, clip_vision_crop="none",
         )
     except RuntimeError as exc:
         assert "previous_frames" in str(exc) and "Update ComfyUI" in str(exc)
     else:
         raise AssertionError("expected RuntimeError on old core")
+
+
+# --- color anchor selection --------------------------------------------------
+
+def _spy_color_anchor(**overrides):
+    """Run a 2-extend generate with color_match on, recording which chunk's
+    frame each color match aimed at. Frames are tagged f0/f1/f2 so we can tell
+    'first chunk' (always f0) from 'previous chunk' (f0 then f1)."""
+    refs = []
+    real_match = _mod._match_color_to_reference
+    _mod._match_color_to_reference = lambda images, reference, strength=1.0: (refs.append(reference), images)[1]
+
+    class _TaggedFrames:
+        def __init__(self, tag, count):
+            self.tag = tag
+            self.count = count
+
+        @property
+        def shape(self):
+            return (self.count, 8, 8, 3)
+
+        def __getitem__(self, item):
+            return self  # last-frame slice keeps the tag
+
+    decoded_seq = [_TaggedFrames("f0", 65), _TaggedFrames("f1", 81), _TaggedFrames("f2", 81)]
+    state = {"i": 0}
+
+    def fake_call_core(class_name, hint="", **kwargs):
+        _CALLS.append((class_name, kwargs))
+        if class_name == "WanSCAILToVideo":
+            return ("pos+", "neg+", {"samples": "lat"}, kwargs["video_frame_offset"] + kwargs["length"])
+        if class_name == "SamplerCustom":
+            return ("out", "den")
+        if class_name == "VAEDecode":
+            frame = decoded_seq[state["i"]]
+            state["i"] += 1
+            return (frame,)
+        return (f"<{class_name}-out>",)
+
+    _mod._call_core = fake_call_core
+    _mod._scail_missing_params = lambda: []
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.cat = lambda chunks, dim=0: chunks[-1]
+
+    kwargs = dict(
+        model="m", clip="c", vae="v", reference_image="ref", pose_video="pose",
+        positive="p", negative="n", width=512, height=896,
+        base_frames=65, extend_segments=2, extend_1_frames=81, extend_2_frames=81,
+        seed=7, steps=6, cfg=1.0, sampler_name="euler", scheduler="simple", shift=5.0,
+        previous_frame_count=5, color_match=True, replacement_mode=False,
+        pose_strength=1.0, pose_start=0.0, pose_end=1.0, clip_vision_crop="none",
+    )
+    kwargs.update(overrides)
+    real_torch = sys.modules.get("torch")
+    sys.modules["torch"] = fake_torch
+    try:
+        _CALLS.clear()
+        _mod.ToobusyWanSCAILExtendSampler().generate(**kwargs)
+    finally:
+        _mod._match_color_to_reference = real_match
+        if real_torch is not None:
+            sys.modules["torch"] = real_torch
+        else:
+            del sys.modules["torch"]
+    return [ref.tag for ref in refs]
+
+
+def test_first_chunk_anchor_always_targets_first():
+    tags = _spy_color_anchor(color_anchor="first chunk")
+    assert tags == ["f0", "f0"], "every extend should match the first chunk (stops cumulative fade)"
+
+
+def test_previous_chunk_anchor_follows_the_chain():
+    tags = _spy_color_anchor(color_anchor="previous chunk")
+    assert tags == ["f0", "f1"], "each extend should match the chunk before it"
 
 
 # --- mask background estimation (torch only) ---------------------------------

--- a/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
+++ b/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
@@ -330,7 +330,14 @@ class ToobusyWanSCAILExtendSampler:
                         "default": True,
                         "label_on": "match chunk colors",
                         "label_off": "raw chunk colors",
-                        "tooltip": "Reinhard LAB color transfer of every extend chunk toward the previous chunk's last frame, so seams don't drift.",
+                        "tooltip": "Reinhard LAB color transfer of every extend chunk so the colors stay consistent down the video.",
+                    },
+                ),
+                "color_anchor": (
+                    ["first chunk", "previous chunk"],
+                    {
+                        "default": "first chunk",
+                        "tooltip": "What color_match aims at. 'first chunk' anchors every chunk to the first chunk's last frame, stopping the cumulative fade that chunk-by-chunk VAE round-trips cause. 'previous chunk' matches each chunk to the one before it (smoothest seams, but follows the drift).",
                     },
                 ),
                 "replacement_mode": ("BOOLEAN", {"default": False, "label_on": "replacement mode", "label_off": "animation mode"}),
@@ -386,6 +393,7 @@ class ToobusyWanSCAILExtendSampler:
         shift,
         previous_frame_count,
         color_match,
+        color_anchor,
         replacement_mode,
         pose_strength,
         pose_start,
@@ -514,7 +522,11 @@ class ToobusyWanSCAILExtendSampler:
             else:
                 kept = decoded[overlap:]
                 if color_match and chunks:
-                    kept = _match_color_to_reference(kept, chunks[-1][-1:])
+                    # Anchor to the first chunk's last frame to stop cumulative
+                    # fade (every chunk targets the same un-drifted color), or
+                    # to the previous chunk for the smoothest seam.
+                    reference = chunks[0][-1:] if color_anchor == "first chunk" else chunks[-1][-1:]
+                    kept = _match_color_to_reference(kept, reference)
             chunks.append(kept)
             previous_frames = kept
 


### PR DESCRIPTION
Operator noticed the extended video gradually loses color. Chunk-based
extension fades cumulatively: each chunk is re-encoded from the
previous chunk's frames through the VAE, and color_match was aiming at
the *previous* chunk, so it followed the drift instead of stopping it.

New color_anchor option: "first chunk" (default) matches every extend
chunk to the first chunk's last frame, so the whole video targets the
same un-faded color and the cumulative fade stops; "previous chunk"
keeps the old behavior (smoothest seams, follows the drift). Tests spy
on the matched reference to lock in first->[f0,f0] vs previous->[f0,f1].

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
