### PR TITLE
feat(scail): target-total auto-plan frame_mode for Wan SCAIL Extend Sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [Unreleased]
+
+### Changed
+- `toobusy Wan SCAIL Extend Sampler`에 **`frame_mode`** 토글 추가. 기본 `target total`
+  모드에서는 **원하는 총 프레임(`target_total_frames`) 하나만** 입력하면 노드가
+  `base_frames` 크기 청크로 자동 분할해 필요한 만큼 익스텐드를 돌립니다 — 중간 청크는
+  모두 같은 크기, 마지막 청크만 목표에 가장 가깝게(4k+1 격자) 자동 조절. 익스텐드
+  슬롯을 한 칸씩 쌓을 필요가 없고, readout이 실제 분할 내역(`81 + 76 = 157 frames ·
+  ~9.8s · 1 extend`)과 청크 수를 보여줍니다. `manual segments` 모드는 기존 +/- 슬롯
+  방식 그대로(파워유저용). auto 모드는 슬롯 상한(8)에 안 묶이고 내부 안전 상한 64까지
+  분할합니다. 포즈 영상보다 긴 목표는 콘솔 경고. (운영자 제안)
+
 ## [0.2.10] - 2026-06-13
 
 ### Added

--- a/js/toobusy_wan_scail_extend_sampler.js
+++ b/js/toobusy_wan_scail_extend_sampler.js
@@ -1,6 +1,58 @@
 import { app } from "../../scripts/app.js";
 
 const MAX_EXTEND_SEGMENTS = 8;
+// Auto mode plans internally, not from slots — mirror the Python sanity cap.
+const MAX_AUTO_SEGMENTS = 64;
+
+// ----- Auto ("target total") planning — mirrors _auto_plan in Python so the
+// on-canvas readout shows exactly the chunk breakdown that will run. -----
+
+function roundToGrid(value, minimum) {
+    value = Math.round(Number(value) || 0);
+    if (value < minimum) value = minimum;
+    const remainder = (value - 1) % 4;
+    let grid;
+    if (remainder === 0) grid = value;
+    else if (remainder <= 2) grid = value - remainder;
+    else grid = value + (4 - remainder);
+    while (grid < minimum) grid += 4;
+    return grid;
+}
+
+function autoPlanLengths(target, chunkFrames, overlap, maxSegments) {
+    overlap = Math.max(0, Math.round(Number(overlap) || 0));
+    const chunk = roundToGrid(chunkFrames, 9);
+    const goal = Math.max(1, Math.round(Number(target) || 0));
+    const base = roundToGrid(Math.min(chunk, goal), 5);
+    const lengths = [base];
+    const perExtend = chunk - overlap;
+    if (perExtend <= 0) return lengths;
+
+    let remaining = goal - base;
+    const minLast = Math.max(9, overlap + 4);
+    let index = 1;
+    while (remaining > 0 && index <= maxSegments) {
+        if (remaining >= perExtend) {
+            lengths.push(chunk);
+            remaining -= perExtend;
+            index += 1;
+            continue;
+        }
+        const lastLength = roundToGrid(remaining + overlap, minLast);
+        const contributed = lastLength - overlap;
+        if (Math.abs(remaining - contributed) < remaining) lengths.push(lastLength);
+        break;
+    }
+    return lengths;
+}
+
+function frameMode(node) {
+    return findWidget(node, "frame_mode")?.value || "manual segments";
+}
+
+function isAuto(node) {
+    return frameMode(node) === "target total";
+}
 
 // Expert tuning hidden by default (Basic view). The extend segment controls
 // are NOT here — growing the video is the whole point of this node, so the
@@ -246,19 +298,33 @@ function updateSegments(node) {
 function updateFramesReadout(node) {
     const readout = findWidget(node, "frames_readout");
     if (!readout) return;
-    const base = Math.max(0, Number(findWidget(node, "base_frames")?.value ?? 0));
     const overlap = Math.max(0, Number(findWidget(node, "previous_frame_count")?.value ?? 5));
-    const count = activeSegmentCount(node);
-    const parts = [base];
-    for (let slot = 1; slot <= count; slot += 1) {
-        const frames = Math.max(0, Number(findWidget(node, `extend_${slot}_frames`)?.value ?? 0));
-        parts.push(Math.max(0, frames - overlap));
+    const mode = findWidget(node, "replacement_mode")?.value ? "Replacement" : "Animation";
+
+    let parts;
+    let extendCount;
+    if (isAuto(node)) {
+        const target = Math.max(0, Number(findWidget(node, "target_total_frames")?.value ?? 0));
+        const chunk = Math.max(0, Number(findWidget(node, "base_frames")?.value ?? 81));
+        const lengths = autoPlanLengths(target, chunk, overlap, MAX_AUTO_SEGMENTS);
+        parts = lengths.map((len, i) => (i === 0 ? len : Math.max(0, len - overlap)));
+        extendCount = lengths.length - 1;
+    } else {
+        const base = Math.max(0, Number(findWidget(node, "base_frames")?.value ?? 0));
+        const count = activeSegmentCount(node);
+        parts = [base];
+        for (let slot = 1; slot <= count; slot += 1) {
+            const frames = Math.max(0, Number(findWidget(node, `extend_${slot}_frames`)?.value ?? 0));
+            parts.push(Math.max(0, frames - overlap));
+        }
+        extendCount = count;
     }
+
     const total = parts.reduce((sum, value) => sum + value, 0);
     const seconds = (total / 16).toFixed(1);
     const sum = parts.length > 1 ? `${parts.join(" + ")} = ` : "";
-    const mode = findWidget(node, "replacement_mode")?.value ? "Replacement" : "Animation";
-    readout.value = `${sum}${total} frames · ~${seconds}s @ 16fps · ${mode}`;
+    const segLabel = isAuto(node) ? ` · ${extendCount} extend${extendCount === 1 ? "" : "s"}` : "";
+    readout.value = `${sum}${total} frames · ~${seconds}s @ 16fps${segLabel} · ${mode}`;
     node.setDirtyCanvas?.(true, true);
 }
 
@@ -272,6 +338,27 @@ function hookReadout(node, name) {
     };
 }
 
+// Show the extend surface (slots + Add) only in manual mode; show
+// target_total_frames only in auto mode. base_frames stays in both (it's the
+// per-chunk size auto mode extends with).
+function applyMode(node) {
+    const auto = isAuto(node);
+    setWidgetVisible(node, findWidget(node, "target_total_frames"), auto);
+    if (auto) {
+        for (let slot = 1; slot <= MAX_EXTEND_SEGMENTS; slot += 1) {
+            setWidgetVisible(node, findWidget(node, `extend_${slot}_frames`), false);
+            setWidgetVisible(node, node[`_toobusyRemoveSegment${slot}`], false);
+        }
+        if (node._toobusyAddBtn) setWidgetVisible(node, node._toobusyAddBtn, false);
+        updateFramesReadout(node);
+        node.setDirtyCanvas?.(true, true);
+        app.graph?.setDirtyCanvas?.(true, true);
+    } else {
+        if (node._toobusyAddBtn) setWidgetVisible(node, node._toobusyAddBtn, true);
+        updateSegments(node);
+    }
+}
+
 function applyAdvanced(node) {
     const advanced = isAdvanced(node);
     for (const name of ADVANCED_WIDGETS) {
@@ -280,7 +367,7 @@ function applyAdvanced(node) {
     if (node._toobusyAdvButton) {
         node._toobusyAdvButton.name = advanced ? "Hide advanced settings" : "Show advanced settings";
     }
-    updateSegments(node);
+    applyMode(node);
 }
 
 app.registerExtension({
@@ -302,6 +389,34 @@ app.registerExtension({
                 segmentsWidget.callback = (...args) => {
                     callback?.apply(segmentsWidget, args);
                     updateSegments(this);
+                };
+            }
+
+            // frame_mode + target_total_frames are appended last in INPUT_TYPES
+            // (to keep saved widget order stable); move them right under
+            // base_frames so the "how long" controls read as one group.
+            {
+                const widgets = this.widgets;
+                const baseFrames = findWidget(this, "base_frames");
+                let anchor = baseFrames ? widgets.indexOf(baseFrames) + 1 : widgets.length;
+                for (const name of ["frame_mode", "target_total_frames"]) {
+                    const widget = findWidget(this, name);
+                    if (!widget) continue;
+                    const from = widgets.indexOf(widget);
+                    if (from >= 0) {
+                        widgets.splice(from, 1);
+                        if (from < anchor) anchor -= 1;
+                    }
+                    widgets.splice(anchor, 0, widget);
+                    anchor += 1;
+                }
+            }
+            const modeWidget = findWidget(this, "frame_mode");
+            if (modeWidget) {
+                const callback = modeWidget.callback;
+                modeWidget.callback = (...args) => {
+                    callback?.apply(modeWidget, args);
+                    applyMode(this);
                 };
             }
 
@@ -350,6 +465,7 @@ app.registerExtension({
                 widgets.splice(anchor, 0, readout);
             }
             hookReadout(this, "base_frames");
+            hookReadout(this, "target_total_frames");
             hookReadout(this, "previous_frame_count");
             hookReadout(this, "replacement_mode");
             for (let slot = 1; slot <= MAX_EXTEND_SEGMENTS; slot += 1) {

--- a/tests/test_wan_scail_extend_sampler.py
+++ b/tests/test_wan_scail_extend_sampler.py
@@ -157,6 +157,57 @@ def test_kept_frame_counts_trims_overlap_on_extends_only():
     assert _mod._kept_frame_counts(plan, 5) == [65, 76, 76]
 
 
+# --- auto ("target total") planning -----------------------------------------
+
+def test_round_to_grid_snaps_to_4k_plus_1():
+    assert _mod._round_to_grid(80, 5) == 81
+    assert _mod._round_to_grid(82, 5) == 81
+    assert _mod._round_to_grid(84, 5) == 85
+    assert _mod._round_to_grid(83, 5) == 81  # equidistant 81/85 breaks downward
+    assert _mod._round_to_grid(7, 9) == 9  # below minimum is lifted to a valid grid
+    assert _mod._round_to_grid(81, 5) == 81  # already on grid is untouched
+
+
+def test_auto_plan_clean_two_chunk_target():
+    # base 81 + (81-5) = 157 lands exactly on the default target.
+    plan = _mod._auto_plan(157, 81, 5, 7)
+    assert plan == [(81, 7), (81, 8)]
+    assert sum(_mod._kept_frame_counts(plan, 5)) == 157
+
+
+def test_auto_plan_uniform_middle_chunks_with_adjusted_last():
+    plan = _mod._auto_plan(300, 81, 5, 0)
+    lengths = [length for length, _seed in plan]
+    # base + full extends are the chunk size; only the last is resized.
+    assert lengths[0] == 81 and all(l == 81 for l in lengths[1:-1])
+    total = sum(_mod._kept_frame_counts(plan, 5))
+    assert abs(total - 300) <= 4  # closest the 4k+1 grid allows
+
+
+def test_auto_plan_seeds_step_per_chunk():
+    plan = _mod._auto_plan(300, 81, 5, 100)
+    seeds = [seed for _length, seed in plan]
+    assert seeds == list(range(100, 100 + len(plan)))
+
+
+def test_auto_plan_single_chunk_when_target_below_chunk():
+    # Target smaller than a chunk: just the base, no tiny trailing extend.
+    plan = _mod._auto_plan(40, 81, 5, 1)
+    assert plan == [(41, 1)]
+
+
+def test_auto_plan_no_extra_chunk_for_tiny_remainder():
+    # base 81, one full extend reaches 157; target 159 is only 2 over — adding a
+    # whole chunk (min +4) would overshoot further than stopping, so stop.
+    plan = _mod._auto_plan(159, 81, 5, 0)
+    assert plan == [(81, 0), (81, 1)]
+
+
+def test_auto_plan_respects_segment_cap():
+    plan = _mod._auto_plan(100000, 81, 5, 0, max_segments=3)
+    assert len(plan) == 1 + 3  # base + capped extends
+
+
 # --- INPUT_TYPES -------------------------------------------------------------
 
 def test_exposes_dynamic_segment_widgets():
@@ -165,6 +216,16 @@ def test_exposes_dynamic_segment_widgets():
     assert required["extend_segments"][1]["max"] == _mod.MAX_EXTEND_SEGMENTS
     for slot in range(1, _mod.MAX_EXTEND_SEGMENTS + 1):
         assert required[f"extend_{slot}_frames"][0] == "INT"
+
+
+def test_exposes_frame_mode_and_target_total():
+    required = _mod.ToobusyWanSCAILExtendSampler.INPUT_TYPES()["required"]
+    assert required["frame_mode"][0] == ["target total", "manual segments"]
+    assert required["frame_mode"][1]["default"] == "target total"
+    assert required["target_total_frames"][0] == "INT"
+    # Appended after the extend slots so saved widget-value order stays stable.
+    keys = list(required.keys())
+    assert keys.index("frame_mode") > keys.index(f"extend_{_mod.MAX_EXTEND_SEGMENTS}_frames")
 
 
 def test_masks_and_clip_vision_are_optional_inputs():
@@ -196,6 +257,23 @@ def test_two_extends_chain_offset_and_previous_frames():
     assert scail[2]["video_frame_offset"] == 141
     # output: 65 + 76 + 76
     assert frame_count == 65 + 76 + 76 == images.count
+
+
+def test_target_total_mode_auto_splits_into_chunks():
+    images, frame_count = _generate(frame_mode="target total", target_total_frames=157, base_frames=81)
+    scail = _called("WanSCAILToVideo")
+    assert len(scail) == 2  # base + one auto extend, no slots needed
+    assert frame_count == 157 == images.count
+
+
+def test_target_total_mode_ignores_manual_segment_widgets():
+    # In auto mode the +/- slot values are irrelevant; the plan comes from target.
+    _, frame_count = _generate(
+        frame_mode="target total", target_total_frames=157, base_frames=81,
+        extend_segments=5, extend_1_frames=300,
+    )
+    assert len(_called("WanSCAILToVideo")) == 2
+    assert frame_count == 157
 
 
 def test_each_chunk_gets_fresh_text_conditioning_and_own_seed():

--- a/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
+++ b/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
@@ -24,6 +24,12 @@ from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _fill_input_defau
 
 MAX_EXTEND_SEGMENTS = 8
 
+# Auto ("target total") mode builds its plan internally instead of from the
+# +/- slots, so it isn't bound by MAX_EXTEND_SEGMENTS. This is just a sanity
+# cap so a tiny chunk size against a huge target can't spin up thousands of
+# chunks (every chunk's decoded frames accumulate in memory before concat).
+MAX_AUTO_SEGMENTS = 64
+
 _SCAIL_NODE = "WanSCAILToVideo"
 _SCAIL_HINT = (
     "Update ComfyUI: WanSCAILToVideo with SCAIL-2 extend inputs "
@@ -179,6 +185,65 @@ def _kept_frame_counts(plan, previous_frame_count):
     return counts
 
 
+def _round_to_grid(value, minimum):
+    """Nearest valid Wan length (4k+1) that is >= minimum. Wan 2.1 wants chunk
+    lengths of the form 4k+1 (5, 9, ..., 65, 81); off-grid lengths degrade or
+    error in the sampler, so auto mode snaps every computed length here."""
+    value = int(round(float(value)))
+    if value < minimum:
+        value = minimum
+    remainder = (value - 1) % 4
+    if remainder == 0:
+        grid = value
+    elif remainder <= 2:
+        grid = value - remainder
+    else:
+        grid = value + (4 - remainder)
+    while grid < minimum:
+        grid += 4
+    return grid
+
+
+def _auto_plan(target_total, chunk_frames, overlap, seed, max_segments=MAX_AUTO_SEGMENTS):
+    """Build [(length, noise_seed), ...] that lands as close to `target_total`
+    output frames as the 4k+1 grid allows.
+
+    The base chunk and every full extend use `chunk_frames`; the base keeps all
+    its frames while each extend contributes `chunk_frames - overlap` (the
+    overlap is re-rendered from the previous tail and trimmed). The final extend
+    is resized to close the gap, and is only added when doing so lands closer to
+    the target than stopping — so a 1-2 frame remainder doesn't spawn a whole
+    extra chunk. Mirrors the JS readout's planning so the on-canvas breakdown
+    matches what actually runs."""
+    overlap = int(overlap)
+    chunk = _round_to_grid(chunk_frames, 9)
+    target = max(1, int(target_total))
+
+    base = _round_to_grid(min(chunk, target), 5)
+    plan = [(base, int(seed))]
+
+    per_extend = chunk - overlap
+    if per_extend <= 0:
+        return plan
+
+    remaining = target - base
+    min_last = max(9, overlap + 4)
+    index = 1
+    while remaining > 0 and index <= max_segments:
+        if remaining >= per_extend:
+            plan.append((chunk, int(seed) + index))
+            remaining -= per_extend
+            index += 1
+            continue
+        # Final partial chunk: snap to grid, keep only if it beats stopping.
+        last_length = _round_to_grid(remaining + overlap, min_last)
+        contributed = last_length - overlap
+        if abs(remaining - contributed) < remaining:
+            plan.append((last_length, int(seed) + index))
+        break
+    return plan
+
+
 # ----- Reinhard color transfer in CIELAB (folds the per-chunk ColorTransfer
 # nodes; matches each frame's LAB mean/std to the previous chunk's last frame
 # so chunk seams don't drift in color). -----
@@ -286,7 +351,7 @@ class ToobusyWanSCAILExtendSampler:
                         "min": 5,
                         "max": 1024,
                         "step": 4,
-                        "tooltip": "Frames of the first chunk. Wan wants 4k+1 lengths (65, 81, ...).",
+                        "tooltip": "Frames of the first chunk, and the per-chunk size auto mode extends with. Wan wants 4k+1 lengths (65, 81, ...).",
                     },
                 ),
                 "extend_segments": ("INT", {"default": 0, "min": 0, "max": MAX_EXTEND_SEGMENTS}),
@@ -365,6 +430,32 @@ class ToobusyWanSCAILExtendSampler:
                 },
             )
 
+        # Appended AFTER the slots so saved-workflow widget value order (which
+        # ends with extend_N_frames) stays intact; the JS repositions them for
+        # display. 'target total' lets you type one goal frame count and let the
+        # node decide how many extends to run, instead of stacking slots.
+        base["required"]["frame_mode"] = (
+            ["target total", "manual segments"],
+            {
+                "default": "target total",
+                "tooltip": (
+                    "target total: enter a goal frame count; the node auto-splits it into "
+                    "base_frames-sized chunks and extends as needed (last chunk trims to fit). "
+                    "manual segments: drive each extend chunk yourself with the +/- slots."
+                ),
+            },
+        )
+        base["required"]["target_total_frames"] = (
+            "INT",
+            {
+                "default": 157,
+                "min": 5,
+                "max": 100000,
+                "step": 4,
+                "tooltip": "Goal output frames in 'target total' mode. The readout shows the actual landed total (4k+1 grid means it may differ by a few frames).",
+            },
+        )
+
         return base
 
     RETURN_TYPES = ("IMAGE", "INT")
@@ -399,6 +490,8 @@ class ToobusyWanSCAILExtendSampler:
         pose_start,
         pose_end,
         clip_vision_crop,
+        frame_mode="manual segments",
+        target_total_frames=157,
         clip_vision=None,
         pose_video_mask=None,
         reference_image_mask=None,
@@ -411,17 +504,39 @@ class ToobusyWanSCAILExtendSampler:
                 f"{'/'.join(missing)} input(s). {_SCAIL_HINT}"
             )
 
-        extend_segments = max(0, min(MAX_EXTEND_SEGMENTS, int(extend_segments)))
-        segment_frames = [
-            int(segment_kwargs.get(f"extend_{slot}_frames", 81))
-            for slot in range(1, MAX_EXTEND_SEGMENTS + 1)
-        ]
         overlap = int(previous_frame_count)
-        for index in range(extend_segments):
-            if segment_frames[index] <= overlap:
-                raise ValueError(
-                    f"extend_{index + 1}_frames ({segment_frames[index]}) must be larger than "
-                    f"previous_frame_count ({overlap}); the chunk would only re-render the overlap."
+        auto_mode = str(frame_mode) == "target total"
+
+        if auto_mode:
+            plan = _auto_plan(target_total_frames, base_frames, overlap, seed)
+        else:
+            extend_segments = max(0, min(MAX_EXTEND_SEGMENTS, int(extend_segments)))
+            segment_frames = [
+                int(segment_kwargs.get(f"extend_{slot}_frames", 81))
+                for slot in range(1, MAX_EXTEND_SEGMENTS + 1)
+            ]
+            for index in range(extend_segments):
+                if segment_frames[index] <= overlap:
+                    raise ValueError(
+                        f"extend_{index + 1}_frames ({segment_frames[index]}) must be larger than "
+                        f"previous_frame_count ({overlap}); the chunk would only re-render the overlap."
+                    )
+            plan = _chunk_plan(base_frames, extend_segments, segment_frames, seed)
+
+        # SCAIL-2 is pose-driven: each chunk walks the pose video at its offset,
+        # so the output can't outrun the pose. Warn (don't hard-clamp) when the
+        # plan asks for more frames than the pose supplies.
+        if pose_video is not None:
+            try:
+                pose_len = int(pose_video.shape[0])
+            except Exception:
+                pose_len = None
+            requested = sum(_kept_frame_counts(plan, overlap))
+            if pose_len and requested > pose_len:
+                print(
+                    f"[toobusy Wan SCAIL] Warning: planned {requested} output frames exceed "
+                    f"pose_video length ({pose_len}). The video can't run longer than the driving "
+                    "pose — shorten the target or supply a longer pose_video."
                 )
 
         if pose_video_mask is not None:
@@ -435,8 +550,6 @@ class ToobusyWanSCAILExtendSampler:
                     "value on this node and on 'Create SCAIL-2 Colored Mask' — mismatched mask "
                     "conventions degrade quality, especially with multiple people."
                 )
-
-        plan = _chunk_plan(base_frames, extend_segments, segment_frames, seed)
 
         # Shared conditioning: fresh text encodes for every chunk (each chunk
         # attaches its own reference latent exactly once), one optional CLIP


### PR DESCRIPTION
## 무엇을 / 왜

운영자 제안: 익스텐드를 슬롯 한 칸씩 쌓는 대신, **원하는 총 프레임 + 선호 청크 크기(예 81)** 만 입력하면 노드가 알아서 분할하게.

`frame_mode` 토글 추가:

- **`target total`(기본)** — `target_total_frames` 하나 입력 → `base_frames` 크기 청크로 자동 분할, 필요한 만큼 익스텐드. 중간 청크는 모두 같은 크기, **마지막 청크만** 목표에 가장 가깝게(Wan 4k+1 격자) 자동 조절. readout이 실제 분할내역(`81 + 76 = 157 frames · ~9.8s · 1 extend`) + 청크 수 표시.
- **`manual segments`** — 기존 +/- 슬롯 그대로(파워유저용).

## 설계 포인트

- auto 모드는 내부에서 플랜을 만들어 슬롯 상한(8)에 안 묶임 — 안전 상한 64.
- 마지막 청크는 "추가하는 게 목표에 더 가까울 때만" 붙임 → 1~2프레임 잔여로 작은 청크가 생기지 않음.
- SCAIL-2는 포즈 영상이 길이를 결정 → 목표가 포즈보다 길면 콘솔 경고(하드 클램프 X).
- **하위호환**: 신규 위젯 2개(`frame_mode`/`target_total_frames`)를 INPUT_TYPES **맨 뒤 append** → 0.2.10 저장 워크플로우의 widget value 순서 안 깨짐. JS가 base_frames 밑으로 재배치.
- ⚠️ 기본값이 `target total`이라 **기존 SCAIL 워크플로우 로드 시 auto 모드로 뜸**(수동 세그먼트 값은 보존되나 미사용). 의도된 동작.
- `_auto_plan` / `_round_to_grid` 는 JS readout 로직과 1:1 미러.

## 테스트

- `tests/test_wan_scail_extend_sampler.py`에 auto-plan/grid snap/wiring 회귀 9개 추가.
- 전 스위트(9파일) + compileall green.
- ⚠️ `node --check`는 작업 PC에 node 미설치라 미실행 → **CI에서 확인 필요**.
- 실제 SCAIL-2 런타임 검증은 운영자 미니PC(최신 코어) 인앱 필요.

버전/태그/Registry 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)