### PR TITLE
feat(scail): color_match strength + whole-chunk anchor controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 ## [Unreleased]
 
 ### Changed
+- `toobusy Wan SCAIL Extend Sampler`의 **color_match에 조절기 2개** 추가. ① **`color_match_strength`**
+  (0~1, 기본 1.0): 청크 색보정을 얼마나 세게 당길지. 씬 색이 실제로 바뀌는 영상(예: 파란
+  클로즈업 → 줌아웃 와이드샷)에서 풀강도 보정이 다음 씬을 파랗게 물들일 때 낮추면 됨(0 =
+  color_match off와 동일). ② **`color_sample`**(whole chunk 기본 / last frame): 앵커 청크의
+  **어느 프레임이 색 기준이 되는지**. `whole chunk`는 청크 전체 색을 평균내 색이 튀는 마지막
+  프레임(클로즈업 등) 하나가 다음 청크를 끌어당기는 걸 막고, `last frame`은 이음새 프레임에
+  정확히 맞춤(가장 매끄러운 이음새, 단 튀는 꼬리 프레임에 취약). 내부 Reinhard LAB 통계를
+  단일 프레임 → 참조 프레임 전체 풀링으로 바꿔 평균 앵커를 지원(단일 프레임 동작은 불변).
+  (운영자 제안 — 색 드리프트 불만 대응)
 - `toobusy Wan SCAIL Extend Sampler`에 **`frame_mode`** 토글 추가. 기본 `target total`
   모드에서는 **원하는 총 프레임(`target_total_frames`) 하나만** 입력하면 노드가
   `base_frames` 크기 청크로 자동 분할해 필요한 만큼 익스텐드를 돌립니다 — 중간 청크는

--- a/js/toobusy_wan_scail_extend_sampler.js
+++ b/js/toobusy_wan_scail_extend_sampler.js
@@ -66,6 +66,8 @@ const ADVANCED_WIDGETS = [
     "previous_frame_count",
     "color_match",
     "color_anchor",
+    "color_sample",
+    "color_match_strength",
     "pose_strength",
     "pose_start",
     "pose_end",
@@ -418,6 +420,26 @@ app.registerExtension({
                     callback?.apply(modeWidget, args);
                     applyMode(this);
                 };
+            }
+
+            // color_sample + color_match_strength are appended last in
+            // INPUT_TYPES too; move them next to color_anchor so the color
+            // controls read as one group (all under Advanced).
+            {
+                const widgets = this.widgets;
+                const colorAnchor = findWidget(this, "color_anchor");
+                let anchor = colorAnchor ? widgets.indexOf(colorAnchor) + 1 : widgets.length;
+                for (const name of ["color_sample", "color_match_strength"]) {
+                    const widget = findWidget(this, name);
+                    if (!widget) continue;
+                    const from = widgets.indexOf(widget);
+                    if (from >= 0) {
+                        widgets.splice(from, 1);
+                        if (from < anchor) anchor -= 1;
+                    }
+                    widgets.splice(anchor, 0, widget);
+                    anchor += 1;
+                }
             }
 
             // Per-segment remove button placed right under its frames widget.

--- a/tests/test_wan_scail_extend_sampler.py
+++ b/tests/test_wan_scail_extend_sampler.py
@@ -228,6 +228,14 @@ def test_exposes_frame_mode_and_target_total():
     assert keys.index("frame_mode") > keys.index(f"extend_{_mod.MAX_EXTEND_SEGMENTS}_frames")
 
 
+def test_exposes_color_sample_and_strength():
+    required = _mod.ToobusyWanSCAILExtendSampler.INPUT_TYPES()["required"]
+    assert required["color_sample"][0] == ["whole chunk", "last frame"]
+    assert required["color_match_strength"][0] == "FLOAT"
+    assert required["color_match_strength"][1]["min"] == 0.0
+    assert required["color_match_strength"][1]["max"] == 1.0
+
+
 def test_masks_and_clip_vision_are_optional_inputs():
     optional = _mod.ToobusyWanSCAILExtendSampler.INPUT_TYPES()["optional"]
     assert optional["pose_video_mask"][0] == "IMAGE"
@@ -284,6 +292,38 @@ def test_each_chunk_gets_fresh_text_conditioning_and_own_seed():
     assert all(kw["positive"] == "<CLIPTextEncode-out>" for kw in scail)
     seeds = [kw["noise_seed"] for kw in _called("SamplerCustom")]
     assert seeds == [10, 11]
+
+
+def test_color_sample_controls_reference_frame_count():
+    # 'last frame' anchors on a single seam frame; 'whole chunk' on every frame
+    # of the anchor chunk (so a color-atypical tail can't dominate).
+    captured = {}
+    real = _mod._match_color_to_reference
+    _mod._match_color_to_reference = lambda images, reference, strength=1.0: (
+        captured.__setitem__("n", reference.count),
+        images,
+    )[1]
+    try:
+        _generate(extend_segments=1, extend_1_frames=81, base_frames=65,
+                  color_match=True, color_sample="last frame")
+        assert captured["n"] == 1
+        _generate(extend_segments=1, extend_1_frames=81, base_frames=65,
+                  color_match=True, color_sample="whole chunk")
+        assert captured["n"] == 65  # the whole first (anchor) chunk
+    finally:
+        _mod._match_color_to_reference = real
+
+
+def test_color_match_strength_zero_skips_transfer():
+    # strength 0 must not call the transfer at all (same as color_match off).
+    calls = []
+    real = _mod._match_color_to_reference
+    _mod._match_color_to_reference = lambda *a, **k: calls.append(1) or a[0]
+    try:
+        _generate(extend_segments=1, extend_1_frames=81, color_match=True, color_match_strength=0.0)
+        assert calls == []
+    finally:
+        _mod._match_color_to_reference = real
 
 
 def test_clip_vision_encoded_only_when_connected():
@@ -451,6 +491,38 @@ def test_color_match_moves_toward_reference_stats():
     matched = _mod._match_color_to_reference(dark, bright)
     assert matched.mean() > dark.mean() + 0.2, "transfer should pull means toward the reference"
     assert matched.min() >= 0.0 and matched.max() <= 1.0
+
+
+def test_color_match_strength_scales_effect():
+    if not _HAS_TORCH:
+        print("SKIP test_color_match_strength_scales_effect (no torch)")
+        return
+    import torch
+
+    dark = torch.full((2, 8, 8, 3), 0.2)
+    bright = torch.full((1, 8, 8, 3), 0.8)
+    none = _mod._match_color_to_reference(dark, bright, strength=0.0)
+    half = _mod._match_color_to_reference(dark, bright, strength=0.5)
+    full = _mod._match_color_to_reference(dark, bright, strength=1.0)
+    assert torch.allclose(none, dark, atol=1e-3), "strength 0 is a no-op"
+    assert dark.mean() < half.mean() < full.mean(), "strength scales the pull"
+
+
+def test_color_match_pools_reference_over_all_frames():
+    # A reference whose tail frame is an outlier (bright) shouldn't dominate when
+    # the whole chunk is the reference: pooled stats pull less than the lone tail.
+    if not _HAS_TORCH:
+        print("SKIP test_color_match_pools_reference_over_all_frames (no torch)")
+        return
+    import torch
+
+    bulk = torch.full((4, 8, 8, 3), 0.2)
+    outlier = torch.full((1, 8, 8, 3), 0.9)
+    whole = torch.cat([bulk, outlier], dim=0)  # last frame is the bright outlier
+    src = torch.full((2, 8, 8, 3), 0.5)
+    to_last = _mod._match_color_to_reference(src, whole[-1:])
+    to_whole = _mod._match_color_to_reference(src, whole)
+    assert to_last.mean() > to_whole.mean(), "matching the whole chunk dilutes the outlier tail"
 
 
 if __name__ == "__main__":

--- a/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
+++ b/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
@@ -295,13 +295,18 @@ def _lab_to_rgb(lab):
 
 def _match_color_to_reference(images, reference, strength=1.0):
     """Per-frame Reinhard LAB transfer of `images` [T,H,W,C] toward the color
-    statistics of `reference` [1,H,W,C]."""
+    statistics of `reference` [N,H,W,C].
+
+    Reference stats are pooled over all reference frames AND pixels, so passing
+    a whole chunk averages out a color-atypical tail (e.g. a blue close-up at
+    the very end) instead of letting one frame set the target. For a single
+    reference frame this is identical to the old per-frame behavior."""
     import torch
 
     source = images[..., :3].float()
     ref_lab = _rgb_to_lab(reference[..., :3].float().to(source.device))
-    ref_mean = ref_lab.mean(dim=(1, 2), keepdim=True)
-    ref_std = ref_lab.std(dim=(1, 2), keepdim=True)
+    ref_mean = ref_lab.mean(dim=(0, 1, 2), keepdim=True)
+    ref_std = ref_lab.std(dim=(0, 1, 2), keepdim=True)
 
     lab = _rgb_to_lab(source)
     mean = lab.mean(dim=(1, 2), keepdim=True)
@@ -402,7 +407,7 @@ class ToobusyWanSCAILExtendSampler:
                     ["first chunk", "previous chunk"],
                     {
                         "default": "first chunk",
-                        "tooltip": "What color_match aims at. 'first chunk' anchors every chunk to the first chunk's last frame, stopping the cumulative fade that chunk-by-chunk VAE round-trips cause. 'previous chunk' matches each chunk to the one before it (smoothest seams, but follows the drift).",
+                        "tooltip": "Which chunk color_match aims at. 'first chunk' anchors every chunk to the first chunk, stopping the cumulative fade that chunk-by-chunk VAE round-trips cause. 'previous chunk' matches each chunk to the one before it (smoothest seams, but follows the drift). See color_sample for which frames set the target.",
                     },
                 ),
                 "replacement_mode": ("BOOLEAN", {"default": False, "label_on": "replacement mode", "label_off": "animation mode"}),
@@ -455,6 +460,34 @@ class ToobusyWanSCAILExtendSampler:
                 "tooltip": "Goal output frames in 'target total' mode. The readout shows the actual landed total (4k+1 grid means it may differ by a few frames).",
             },
         )
+        # Color-match tuning — appended last (like frame_mode) to keep saved
+        # widget-value order stable; the JS moves them next to color_anchor.
+        base["required"]["color_sample"] = (
+            ["whole chunk", "last frame"],
+            {
+                "default": "whole chunk",
+                "tooltip": (
+                    "Which frames of the anchor chunk set the color target. 'whole chunk' "
+                    "averages the chunk's color so a color-atypical tail (e.g. a blue close-up "
+                    "right before a zoom-out) can't drag the next chunk's color. 'last frame' "
+                    "matches the seam frame exactly (tightest seam, but vulnerable to that tail)."
+                ),
+            },
+        )
+        base["required"]["color_match_strength"] = (
+            "FLOAT",
+            {
+                "default": 1.0,
+                "min": 0.0,
+                "max": 1.0,
+                "step": 0.05,
+                "tooltip": (
+                    "How hard color_match pulls each chunk toward the target color. 1.0 = full "
+                    "transfer, 0.0 = none (same as turning color_match off). Lower it when scenes "
+                    "legitimately change color and full matching tints them."
+                ),
+            },
+        )
 
         return base
 
@@ -492,6 +525,8 @@ class ToobusyWanSCAILExtendSampler:
         clip_vision_crop,
         frame_mode="manual segments",
         target_total_frames=157,
+        color_sample="whole chunk",
+        color_match_strength=1.0,
         clip_vision=None,
         pose_video_mask=None,
         reference_image_mask=None,
@@ -634,12 +669,16 @@ class ToobusyWanSCAILExtendSampler:
                 kept = decoded
             else:
                 kept = decoded[overlap:]
-                if color_match and chunks:
-                    # Anchor to the first chunk's last frame to stop cumulative
-                    # fade (every chunk targets the same un-drifted color), or
-                    # to the previous chunk for the smoothest seam.
-                    reference = chunks[0][-1:] if color_anchor == "first chunk" else chunks[-1][-1:]
-                    kept = _match_color_to_reference(kept, reference)
+                strength = max(0.0, min(1.0, float(color_match_strength)))
+                if color_match and strength > 0.0 and chunks:
+                    # Anchor to the first chunk (stops cumulative fade — every
+                    # chunk targets the same un-drifted color) or the previous
+                    # chunk (smoothest seam). color_sample decides whether the
+                    # whole anchor chunk sets the target color (robust to a
+                    # color-atypical tail) or just its last/seam frame.
+                    anchor_chunk = chunks[0] if color_anchor == "first chunk" else chunks[-1]
+                    reference = anchor_chunk if color_sample == "whole chunk" else anchor_chunk[-1:]
+                    kept = _match_color_to_reference(kept, reference, strength=strength)
             chunks.append(kept)
             previous_frames = kept
 


### PR DESCRIPTION
## 무엇을 / 왜

운영자 관찰: 애니메이션 모드 모션전이에서 **파란 새 캐릭터가 클로즈업으로 끝나는 청크** 뒤에 줌아웃 와이드샷 청크가 오면, color_match가 그 파란 마지막 프레임에 색을 맞추는 바람에 다음 씬 전체가 파랗게 물듦.

원인은 두 갈래:
1. 익스텐드 자체가 이전 청크 꼬리(`previous_frames`, 5프레임)에서 이어 그림 — SCAIL 본질이라 못 건드림(사용자가 경계 위치를 잡아야 함).
2. **color_match가 앵커 청크의 마지막 1프레임 색 통계에 맞춤** — 우리가 제어 가능한 부분.

이 PR은 2번을 위한 조절기 2개를 추가:

- **`color_match_strength`** (0~1, 기본 1.0): 청크 색보정 강도. 씬 색이 실제로 바뀌는 영상에서 낮추면 됨. 0이면 color_match off와 동일(호출 자체 스킵).
- **`color_sample`** (`whole chunk` 기본 / `last frame`): 앵커 청크의 **어느 프레임이 색 기준**인지. `whole chunk`는 청크 전체 색을 평균내 튀는 꼬리 프레임 하나가 다음 청크를 끌어당기는 걸 방지. `last frame`은 이음새에 정확히 맞춤(기존 동작).

(OFF 기능은 기존 `color_match` 토글로 이미 존재 — 그대로 둠.)

## 구현 메모

- `_match_color_to_reference`가 참조 통계를 프레임별이 아니라 **참조 프레임 전체에 걸쳐 풀링**(dim 0,1,2)하도록 변경. 단일 프레임에선 결과 동일(하위호환), 다중 프레임이면 평균 앵커가 됨.
- 신규 위젯 2개는 INPUT_TYPES **맨 뒤 append**(저장 워크플로우 위젯값 순서 보존) → JS가 `color_anchor` 옆으로 재배치, Advanced에 게이팅.
- ⚠️ `color_sample` 기본값을 `whole chunk`로 둠 — 단일 프레임 대비 결과가 살짝 달라지지만(이음새 약간 덜 타이트, 대신 아웃라이어에 강건) 보고된 문제를 기본값에서 바로 완화. 가장 매끄러운 이음새가 필요하면 `last frame`.

## 테스트

- 신규 5개: strength 스케일링/0=no-op, 프레임 풀링(아웃라이어 희석), color_sample 배선(1 vs 전체 프레임), INPUT_TYPES 노출.
- 전 스위트(9파일) plain 3.11 + **torch venv(ComfyUI 2.12.0+cu130)** 둘 다 green, compileall green.
- ⚠️ `node --check`(JS)는 작업 PC에 node 없어 CI에서 확인.
- 실제 SCAIL-2 런타임/색 결과는 운영자 미니PC 인앱.

버전/태그/Registry 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)