### PR TITLE
fix(ideogram): Image → Ideogram Layout produced no object boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### Fixed
+- `toobusy Image → Ideogram Layout`(Unreleased): 실런타임에서 **오브젝트 박스 0개**로 나오던
+  문제 수정. 원인 = `dense_region_caption`의 `data` 출력이 **라벨 없는 맨 박스 리스트**라
+  파서가 못 읽음. 오브젝트 추출을 **`caption_to_phrase_grounding`**(캡션을 그라운딩 → bbox+라벨)
+  으로 교체하고, 파서를 맨-박스-리스트·task-token 래핑까지 흡수하게 보강. 라벨에서 **특수토큰
+  (`</s>`,`<s>`,`<pad>`) 스트립**(예: `</s>TIMIAMENT` → 정리). `medium` 드롭다운
+  (photograph/graphic_design/illustration, 기본 photograph) 추가 — 사진을 graphic_design으로
+  하드코딩하던 것 수정, photo/medium 상호배타 유지.
+
 ### Added
 - **`toobusy Image → Ideogram Layout`** 신규 노드: 일반 이미지 1장을 **Florence-2로 분석**해
   Ideogram4 structured-JSON **초안**(high_level_description + style + bbox 박힌 text/obj

--- a/image_to_layout_node/image_to_layout.py
+++ b/image_to_layout_node/image_to_layout.py
@@ -88,42 +88,79 @@ def _grow_box(bbox):
     return [x_min, y_min, x_max, y_max]
 
 
-def _iter_regions(data):
-    """Yield (box, label) from Florence2Run's `data` output, defensively across
-    shapes: {'bboxes':[...], 'labels':[...]}, a single-item list wrapping that,
-    or a list of {'box'|'bbox':[...], 'label'|'text':str} entries."""
-    # dense_region_caption is sometimes wrapped in a one-item list per image;
-    # only unwrap when the inner dict is a {bboxes/labels} container, not a lone
-    # {box,label} entry (which the list-of-entries branch below handles).
-    if (
-        isinstance(data, list)
-        and len(data) == 1
-        and isinstance(data[0], dict)
-        and any(key in data[0] for key in ("bboxes", "labels", "quad_boxes"))
-    ):
-        data = data[0]
+_SPECIAL_TOKENS = ("</s>", "<s>", "<pad>", "<unk>")
 
-    if isinstance(data, dict) and ("bboxes" in data or "labels" in data):
+
+def _clean_text(value):
+    """Strip Florence's special tokens (</s>, <s>, <pad>, ...) that leak into
+    region labels — kijai only cleans the final caption string, not the labels."""
+    text = str(value)
+    for token in _SPECIAL_TOKENS:
+        text = text.replace(token, "")
+    return text.strip()
+
+
+def _box_extent(box):
+    """Reduce an 8-number quad polygon to an [x1,y1,x2,y2] extent; pass other
+    boxes through."""
+    if isinstance(box, (list, tuple)) and len(box) == 8:
+        xs = box[0::2]
+        ys = box[1::2]
+        return [min(xs), min(ys), max(xs), max(ys)]
+    return box
+
+
+def _is_number_box(value):
+    return (
+        isinstance(value, (list, tuple))
+        and len(value) >= 4
+        and all(isinstance(n, (int, float)) for n in value[:8])
+    )
+
+
+def _iter_regions(data):
+    """Yield (box, clean_label) from Florence2Run's `data` output, defensively
+    across the shapes different tasks produce:
+      * {'bboxes':[...], 'labels':[...]}           (caption_to_phrase_grounding)
+      * a bare list of [x1,y1,x2,y2] boxes         (dense_region_caption)
+      * [{'box'|'bbox':[...], 'label'|'text':str}] (ocr_with_region)
+      * any of the above wrapped in a one-item per-image list
+      * a dict keyed by the task token: {'<TASK>': {bboxes, labels}}"""
+    # Unwrap a one-item per-image list around a dict container or a box list.
+    if isinstance(data, list) and len(data) == 1 and isinstance(data[0], (dict, list)):
+        inner = data[0]
+        if isinstance(inner, dict) and any(k in inner for k in ("bboxes", "labels", "quad_boxes")):
+            data = inner
+        elif isinstance(inner, list):
+            data = inner  # [[box, box, ...]] -> [box, box, ...]
+
+    # Dig through a task-token-keyed wrapper: {'<DENSE_REGION_CAPTION>': {...}}.
+    if isinstance(data, dict) and not any(
+        k in data for k in ("bboxes", "labels", "quad_boxes", "box", "bbox")
+    ):
+        for value in data.values():
+            if isinstance(value, dict) and any(k in value for k in ("bboxes", "labels", "quad_boxes")):
+                data = value
+                break
+
+    if isinstance(data, dict) and any(k in data for k in ("bboxes", "labels", "quad_boxes")):
         boxes = data.get("bboxes") or data.get("quad_boxes") or []
         labels = data.get("labels") or []
         for index, box in enumerate(boxes):
-            # quad_boxes are 8-number polygons; reduce to an x/y extent.
-            if isinstance(box, (list, tuple)) and len(box) == 8:
-                xs = box[0::2]
-                ys = box[1::2]
-                box = [min(xs), min(ys), max(xs), max(ys)]
             label = labels[index] if index < len(labels) else ""
-            yield box, str(label).strip()
+            yield _box_extent(box), _clean_text(label)
         return
 
     if isinstance(data, list):
         for entry in data:
-            if not isinstance(entry, dict):
-                continue
-            box = entry.get("box") or entry.get("bbox")
-            label = entry.get("label") or entry.get("text") or ""
-            if box is not None:
-                yield box, str(label).strip()
+            if isinstance(entry, dict):
+                box = entry.get("box") or entry.get("bbox") or entry.get("quad_boxes")
+                label = entry.get("label") or entry.get("text") or ""
+                if box is not None:
+                    yield _box_extent(box), _clean_text(label)
+            elif _is_number_box(entry):
+                # Bare box from dense_region_caption (no label in this output).
+                yield _box_extent(entry), ""
 
 
 def _extract_palette(image, limit):
@@ -153,16 +190,17 @@ def _extract_palette(image, limit):
         return []
 
 
-def _florence(image, model, task, max_new_tokens=512):
+def _florence(image, model, task, text_input="", max_new_tokens=512):
     """Call Florence2Run for one task -> (caption_string, data). Re-raises a
     missing-node error with a clear install hint (the shared _call_node only
-    says the node is unavailable)."""
+    says the node is unavailable). `text_input` feeds grounding tasks like
+    caption_to_phrase_grounding (the phrases to locate)."""
     try:
         out = _call_node(
             _FLORENCE_NODE,
             image=image,
             florence2_model=model,
-            text_input="",
+            text_input=str(text_input),
             task=task,
             fill_mask=False,
             keep_model_loaded=True,
@@ -217,6 +255,13 @@ class ToobusyImageToIdeogramLayout:
                     cls.CAPTION_TASKS,
                     {"default": "more_detailed_caption"},
                 ),
+                "medium": (
+                    ["photograph", "graphic_design", "illustration"],
+                    {
+                        "default": "photograph",
+                        "tooltip": "What kind of image this is, written into style_description.medium. Photos -> photograph; thumbnails/posters -> graphic_design.",
+                    },
+                ),
                 "max_elements": ("INT", {"default": 12, "min": 1, "max": 64}),
                 "include_ocr_text": ("BOOLEAN", {"default": True, "label_on": "OCR text boxes", "label_off": "objects only"}),
                 "include_color_palette": ("BOOLEAN", {"default": True, "label_on": "extract palette", "label_off": "no palette"}),
@@ -243,6 +288,7 @@ class ToobusyImageToIdeogramLayout:
         florence2_model,
         analysis_mode="Full Setup",
         caption_detail="more_detailed_caption",
+        medium="photograph",
         max_elements=12,
         include_ocr_text=True,
         include_color_palette=True,
@@ -257,8 +303,12 @@ class ToobusyImageToIdeogramLayout:
         high_level_description = caption or "An image to lay out."
 
         elements = []
-        # Objects: dense region captions become obj elements (desc = label).
-        _, obj_data = _florence(image, florence2_model, "dense_region_caption")
+        # Objects: ground the caption's phrases to boxes. caption_to_phrase_grounding
+        # returns {bboxes, labels} (boxes WITH descriptions) — unlike
+        # dense_region_caption, whose data output is a bare box list with no labels.
+        _, obj_data = _florence(
+            image, florence2_model, "caption_to_phrase_grounding", text_input=caption
+        )
         for box, label in _iter_regions(obj_data):
             norm = _norm_box(box, width, height)
             if norm is None:
@@ -310,13 +360,15 @@ class ToobusyImageToIdeogramLayout:
                 {"type": "obj", "bbox": [250, 250, 750, 750], "desc": high_level_description}
             )
 
+        # photo vs graphic: keep the two mutually exclusive (Ideogram convention).
+        is_photo = medium == "photograph"
         style_description = {
             # v1: light, editable defaults — Florence captions don't give a
             # structured style breakdown, so the user refines these in the builder.
             "aesthetics": "draft from image analysis; refine in the builder",
             "lighting": "",
-            "photo": "",
-            "medium": "graphic_design",
+            "photo": "photograph, refine in the builder" if is_photo else "",
+            "medium": str(medium),
         }
         if palette:
             style_description["color_palette"] = palette[:STYLE_PALETTE_MAX]

--- a/tests/test_image_to_layout.py
+++ b/tests/test_image_to_layout.py
@@ -122,10 +122,10 @@ def test_outputs_are_ideogram_json_plus_fields():
 
 # --- region parsing / bbox ---------------------------------------------------
 
-def test_dense_region_caption_becomes_obj_elements_in_ideogram_bbox():
+def test_caption_to_phrase_grounding_becomes_obj_elements_in_ideogram_bbox():
     payload, hld, _bg, _pal, w, h = _run({
         "more_detailed_caption": ("A bold poster with a person and a headline.", None),
-        "dense_region_caption": ("", {"bboxes": [[100, 50, 850, 480]], "labels": ["a surprised person"]}),
+        "caption_to_phrase_grounding": ("", {"bboxes": [[100, 50, 850, 480]], "labels": ["a surprised person"]}),
     })
     assert hld.startswith("A bold poster")
     elements = payload["compositional_deconstruction"]["elements"]
@@ -139,7 +139,7 @@ def test_dense_region_caption_becomes_obj_elements_in_ideogram_bbox():
 
 def test_ocr_with_region_becomes_text_elements():
     payload, *_ = _run({
-        "dense_region_caption": ("", {"bboxes": [], "labels": []}),
+        "caption_to_phrase_grounding": ("", {"bboxes": [], "labels": []}),
         "ocr_with_region": ("", {"bboxes": [[120, 520, 360, 950]], "labels": ["HEADLINE"]}),
     })
     text = [el for el in payload["compositional_deconstruction"]["elements"] if el["type"] == "text"]
@@ -150,7 +150,7 @@ def test_ocr_with_region_becomes_text_elements():
 def test_quad_boxes_are_reduced_to_extent():
     payload, *_ = _run({
         "ocr_with_region": ("", {"quad_boxes": [[120, 520, 360, 520, 360, 950, 120, 950]], "labels": ["X"]}),
-        "dense_region_caption": ("", None),
+        "caption_to_phrase_grounding": ("", None),
     })
     text = [el for el in payload["compositional_deconstruction"]["elements"] if el["type"] == "text"]
     assert text and text[0]["bbox"] == [520, 120, 950, 360]
@@ -158,7 +158,7 @@ def test_quad_boxes_are_reduced_to_extent():
 
 def test_list_of_entries_shape_is_parsed():
     payload, *_ = _run({
-        "dense_region_caption": ("", [{"bbox": [10, 10, 500, 500], "label": "thing"}]),
+        "caption_to_phrase_grounding": ("", [{"bbox": [10, 10, 500, 500], "label": "thing"}]),
     }, include_ocr_text=False)
     objs = [el for el in payload["compositional_deconstruction"]["elements"] if el["type"] == "obj"]
     assert objs and objs[0]["desc"] == "thing"
@@ -168,10 +168,38 @@ def test_normalized_ocr_coords_scale_to_thousand():
     # ocr_with_region often returns 0..1 normalized boxes.
     payload, *_ = _run({
         "ocr_with_region": ("", [{"box": [0.1, 0.2, 0.4, 0.6], "label": "T"}]),
-        "dense_region_caption": ("", None),
+        "caption_to_phrase_grounding": ("", None),
     })
     text = [el for el in payload["compositional_deconstruction"]["elements"] if el["type"] == "text"]
     assert text and text[0]["bbox"] == [200, 100, 600, 400]
+
+
+def test_bare_box_list_is_parsed_as_objects():
+    # dense_region_caption's data output is a bare list of [x1,y1,x2,y2] boxes
+    # (no labels). _iter_regions must still yield boxes.
+    regions = list(_mod._iter_regions([[10, 10, 500, 500], [0, 0, 200, 200]]))
+    assert [box for box, _ in regions] == [[10, 10, 500, 500], [0, 0, 200, 200]]
+    assert all(label == "" for _, label in regions)
+    # also the one-item-per-image wrapping: [[box, box]]
+    wrapped = list(_mod._iter_regions([[[10, 10, 500, 500]]]))
+    assert wrapped and wrapped[0][0] == [10, 10, 500, 500]
+
+
+def test_task_token_keyed_wrapper_is_parsed():
+    data = {"<CAPTION_TO_PHRASE_GROUNDING>": {"bboxes": [[1, 2, 3, 4]], "labels": ["cat"]}}
+    regions = list(_mod._iter_regions(data))
+    assert regions == [([1, 2, 3, 4], "cat")]
+
+
+def test_special_tokens_stripped_from_labels():
+    assert _mod._clean_text("</s>person<pad>") == "person"
+    assert _mod._clean_text("<s>a man</s>") == "a man"
+    payload, *_ = _run({
+        "more_detailed_caption": ("A man.", None),
+        "caption_to_phrase_grounding": ("", {"bboxes": [[0, 0, 500, 500]], "labels": ["</s>a man"]}),
+    }, include_ocr_text=False)
+    objs = payload["compositional_deconstruction"]["elements"]
+    assert objs[0]["desc"] == "a man"
 
 
 # --- options -----------------------------------------------------------------
@@ -179,7 +207,7 @@ def test_normalized_ocr_coords_scale_to_thousand():
 def test_max_elements_caps_and_keeps_largest():
     boxes = [[0, 0, 100, 100], [0, 0, 900, 900], [0, 0, 300, 300]]
     payload, *_ = _run({
-        "dense_region_caption": ("", {"bboxes": boxes, "labels": ["small", "big", "mid"]}),
+        "caption_to_phrase_grounding": ("", {"bboxes": boxes, "labels": ["small", "big", "mid"]}),
     }, max_elements=2, include_ocr_text=False)
     descs = {el["desc"] for el in payload["compositional_deconstruction"]["elements"]}
     assert descs == {"big", "mid"}  # the two largest survive
@@ -187,7 +215,7 @@ def test_max_elements_caps_and_keeps_largest():
 
 def test_simplify_small_text_drops_tiny_ocr():
     payload, *_ = _run({
-        "dense_region_caption": ("", None),
+        "caption_to_phrase_grounding": ("", None),
         "ocr_with_region": ("", {"bboxes": [[0, 0, 10, 10]], "labels": ["©"]}),
     }, simplify_small_text=True)
     assert all(el["type"] != "text" for el in payload["compositional_deconstruction"]["elements"])
@@ -197,6 +225,15 @@ def test_empty_analysis_falls_back_to_one_obj():
     payload, hld, *_ = _run({"more_detailed_caption": ("Just a scene.", None)})
     elements = payload["compositional_deconstruction"]["elements"]
     assert len(elements) == 1 and elements[0]["type"] == "obj"
+
+
+def test_medium_option_sets_style_and_photo_exclusivity():
+    photo, *_ = _run({"more_detailed_caption": ("A snowy scene.", None)}, medium="photograph")
+    assert photo["style_description"]["medium"] == "photograph"
+    assert photo["style_description"]["photo"]  # photo filled for photographs
+    graphic, *_ = _run({"more_detailed_caption": ("A thumbnail.", None)}, medium="graphic_design")
+    assert graphic["style_description"]["medium"] == "graphic_design"
+    assert graphic["style_description"]["photo"] == ""  # no photo for graphics
 
 
 # --- error path --------------------------------------------------------------


### PR DESCRIPTION
## 증상 (운영자 실테스트)

눈 사진(남자+아이 2명+썰매)을 large-ft로 돌렸는데 결과가 이상함:
- 캡션은 정확
- **오브젝트 박스 0개** (남자/아이/썰매 하나도 안 잡힘)
- 유일한 요소가 `text: "</s>TIMIAMENT"` — 글자 없는 사진에 OCR 헛것 + EOS 토큰 누수
- 사진인데 `medium: graphic_design`

## 원인 (kijai 소스로 확정)

- `dense_region_caption`의 `data` 출력은 `out_data.append(bboxes)` = **라벨 없는 맨 박스 리스트**. 우리 파서는 `{bboxes,labels}` 딕셔너리를 기대해서 **0개**가 됨.
- kijai는 최종 캡션 문자열만 `</s>` 제거 → **라벨 안 특수토큰은 안 닦임**.

## 수정

- 오브젝트 추출 **`dense_region_caption` → `caption_to_phrase_grounding`**(캡션을 text_input으로 그라운딩) → `{bboxes, labels}` = **박스 + 설명**. 눈 사진이면 "두 아이/갈색 베스트 남자/분홍 썰매/덤불"이 박스로 잡힐 것.
- `_iter_regions` 보강: 맨-박스-리스트, one-item 래핑, task-token 키 래핑(`{'<TASK>': {...}}`)까지 흡수.
- **특수토큰 스트립**(`</s>`,`<s>`,`<pad>`,`<unk>`) — 라벨/OCR 텍스트 전부.
- `medium` 드롭다운(photograph 기본) 추가 — 사진을 graphic_design으로 박던 것 수정, photo/medium 상호배타.

## 테스트

- 신규 5개(grounding task / 맨-박스 리스트 / task-token 래퍼 / 토큰 스트립 / medium) + 기존 갱신. 전 스위트(10파일) plain+torch venv green, compileall green.
- ⚠️ 실 Florence는 여전히 운영자 미니PC 재확인 필요 — **같은 눈 사진으로 다시 돌려 박스가 잡히는지** 봐주세요. 형태 또 다르면 파서 한 줄 더 조정.

버전/태그/Registry 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)