### PR TITLE
feat(ideogram): Pull-from-input bridge for the Layout Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### Added
+- `toobusy Ideogram Layout Builder`에 **`⟳ Pull from input` 버튼 + 입력 소켓 2개**(`imported_json`,
+  `image`) 추가. `Image → Ideogram Layout`의 `ideogram_json`을 `imported_json`에, 원본 이미지를
+  `image`에 연결한 뒤 버튼을 누르면 — **그 빌더에 필요한 앞단 노드만 부분 실행**(전체 큐 안 돌림)
+  하고, 결과 JSON을 **캔버스에 박스로** 올리고 원본 이미지를 **반투명 백드롭으로** 깔아줘요(박스가
+  실제 이미지 위에 정확히 겹침). 빌더를 `OUTPUT_NODE`로 만들고 실행 시 값을 프론트로 돌려주는
+  방식(`onExecuted`). 기존 수동 빌더/Import polished 기능은 0 변경. (Florence는 한 번은 실행됨 —
+  같은 이미지면 ComfyUI가 캐시.)
+
 ### Fixed
 - `toobusy Image → Ideogram Layout`(Unreleased): 실런타임에서 **오브젝트 박스 0개**로 나오던
   문제 수정. 원인 = `dense_region_caption`의 `data` 출력이 **라벨 없는 맨 박스 리스트**라

--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -273,13 +273,30 @@ class IdeogramLayoutBuilder:
                         "step": 1,
                     },
                 ),
-            }
+            },
+            "optional": {
+                # Bridge inputs for the "⟳ Pull from input" button: connect an
+                # Image → Ideogram Layout draft here, run the upstream, then Pull
+                # to load it onto the canvas (json) and under it (image backdrop).
+                "imported_json": (
+                    "STRING",
+                    {
+                        "forceInput": True,
+                        "tooltip": "Connect an Ideogram JSON draft (e.g. from Image → Ideogram Layout). Run upstream, then press '⟳ Pull from input' on the node to load it onto the canvas.",
+                    },
+                ),
+                "image": (
+                    "IMAGE",
+                    {"tooltip": "Optional: the analyzed image. Pulling lays it under the canvas as the reference backdrop so boxes land on the real image."},
+                ),
+            },
         }
 
     RETURN_TYPES = ("STRING", "INT", "INT")
     RETURN_NAMES = ("ideogram_json", "width", "height")
     FUNCTION = "build"
     CATEGORY = "toobusy/Plan"
+    OUTPUT_NODE = True
 
     def build(
         self,
@@ -296,6 +313,8 @@ class IdeogramLayoutBuilder:
         include_global_palette=True,
         strict_text=True,
         reinforce_text=True,
+        imported_json="",
+        image=None,
     ):
         elements = []
         for item in _load_elements(elements_json):
@@ -365,7 +384,45 @@ class IdeogramLayoutBuilder:
             },
         }
 
-        return (json.dumps(payload, ensure_ascii=False, indent=2), int(width), int(height))
+        result = (json.dumps(payload, ensure_ascii=False, indent=2), int(width), int(height))
+
+        # Send the bridge inputs back to the frontend so the "⟳ Pull from input"
+        # button can load them onto the canvas / backdrop. This never changes the
+        # node's own output — imported_json is a frontend bridge, not merged here.
+        ui = {}
+        if isinstance(imported_json, str) and imported_json.strip():
+            ui["toobusy_import"] = [imported_json]
+        if image is not None:
+            data_url = _image_to_data_url(image)
+            if data_url:
+                ui["toobusy_image"] = [data_url]
+        if ui:
+            return {"ui": ui, "result": result}
+        return result
+
+
+def _image_to_data_url(image, max_edge=1536):
+    """First frame of an IMAGE tensor -> downscaled JPEG data URL for the canvas
+    backdrop. Returns '' if PIL/numpy/torch aren't available."""
+    try:
+        import base64
+        import io
+
+        import numpy as np
+        from PIL import Image as PILImage
+
+        frame = image[0].detach().cpu().numpy()
+        array = (frame[..., :3].clip(0.0, 1.0) * 255.0).astype("uint8")
+        pil = PILImage.fromarray(array)
+        w, h = pil.size
+        scale = min(1.0, float(max_edge) / float(max(w, h)))
+        if scale < 1.0:
+            pil = pil.resize((max(1, int(w * scale)), max(1, int(h * scale))))
+        buffer = io.BytesIO()
+        pil.save(buffer, format="JPEG", quality=85)
+        return "data:image/jpeg;base64," + base64.b64encode(buffer.getvalue()).decode("ascii")
+    except Exception:
+        return ""
 
 
 NODE_CLASS_MAPPINGS = {

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -1,4 +1,5 @@
 import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
 
 const NODE_CLASS = "IdeogramLayoutBuilder";
 const CANVAS_SIZE = 1000;
@@ -2181,9 +2182,83 @@ function installEditor(node) {
         importDialog.open();
     }
 
+    // ----- "Pull from input": load an Ideogram JSON connected to the node's
+    // `imported_json` socket onto the canvas (and the `image` socket under it as
+    // the backdrop). Runs ONLY the nodes feeding this builder — not the whole
+    // graph — then applies the result when it arrives via onExecuted. -----
+    let pullPending = false;
+
+    function applyPulled() {
+        const raw = node._toobusyImport;
+        if (!raw) return false;
+        let parsed;
+        try {
+            parsed = JSON.parse(raw);
+        } catch {
+            return false;
+        }
+        const state = payloadToState(parsed);
+        if (!state) return false;
+        applyState(state);
+        if (node._toobusyImage) setReferenceImage(node._toobusyImage);
+        return true;
+    }
+
+    const previousOnExecuted = node.onExecuted;
+    node.onExecuted = function (message) {
+        previousOnExecuted?.apply(this, arguments);
+        if (message && message.toobusy_import) node._toobusyImport = message.toobusy_import[0];
+        if (message && message.toobusy_image) node._toobusyImage = message.toobusy_image[0];
+        if (pullPending) {
+            pullPending = false;
+            applyPulled();
+        }
+    };
+
+    async function pullFromInput() {
+        try {
+            const prompt = await app.graphToPrompt();
+            const output = prompt.output || {};
+            const targetId = String(node.id);
+            if (!output[targetId]) {
+                if (!applyPulled()) {
+                    window.alert("Connect an Ideogram JSON to 'imported_json', then press Pull.");
+                }
+                return;
+            }
+            // Keep only this builder and the nodes feeding it, so the rest of the
+            // graph (e.g. heavy generation) does not run.
+            const keep = new Set([targetId]);
+            const stack = [targetId];
+            while (stack.length) {
+                const id = stack.pop();
+                const inputs = (output[id] && output[id].inputs) || {};
+                for (const value of Object.values(inputs)) {
+                    if (Array.isArray(value) && value.length === 2 && output[String(value[0])]) {
+                        const source = String(value[0]);
+                        if (!keep.has(source)) {
+                            keep.add(source);
+                            stack.push(source);
+                        }
+                    }
+                }
+            }
+            const pruned = {};
+            for (const id of keep) pruned[id] = output[id];
+            pullPending = true;
+            await api.queuePrompt(0, { output: pruned, workflow: prompt.workflow });
+        } catch (err) {
+            pullPending = false;
+            if (!applyPulled()) {
+                window.alert(`Pull failed: ${err.message}. Try queuing the graph once.`);
+            }
+        }
+    }
+
     presetBar.append(
         presetBarTitle,
         presetSelectEl,
+        makeButton("⟳ Pull from input", "Run only the nodes feeding this builder and load the resulting Ideogram JSON onto the canvas (with the connected image as backdrop)", pullFromInput),
         makeButton("Import polished", "Paste a Prompt Polish / Ideogram JSON to load it (preview before it replaces the layout)", openImportPolishedDialog),
         makeButton("Reset", "Reset this builder to a fresh empty layout", resetLayout),
         makeButton("Save", "Save current layout as a named preset", () => {

--- a/tests/test_ideogram_layout_builder.py
+++ b/tests/test_ideogram_layout_builder.py
@@ -1,0 +1,95 @@
+"""Regression tests for the Ideogram Layout Builder's Pull-from-input bridge.
+
+The builder gained optional `imported_json` / `image` inputs and OUTPUT_NODE so
+the frontend "⟳ Pull from input" button can load an upstream Ideogram draft onto
+the canvas. These tests lock the contract that must not drift:
+
+  * the bridge inputs are exposed (imported_json forceInput + image);
+  * imported_json is echoed to the `ui` payload, NOT merged into the output;
+  * without bridge inputs the node still returns a plain tuple;
+  * OUTPUT_NODE is set.
+
+Standalone- and pytest-runnable, no ComfyUI runtime (nodes.py is self-contained).
+"""
+
+import importlib.util
+import json
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load():
+    path = os.path.join(ROOT, "ideogram_layout_builder", "nodes.py")
+    spec = importlib.util.spec_from_file_location("toobusy_ilb_nodes", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load()
+_Builder = _mod.IdeogramLayoutBuilder
+
+
+def _build(**overrides):
+    kwargs = dict(
+        high_level_description="A poster.",
+        aesthetics="clean",
+        lighting="soft",
+        photo="",
+        medium="graphic_design",
+        global_palette="#111111, #FFFFFF",
+        background="studio",
+        elements_json="[]",
+        width=2048,
+        height=2048,
+    )
+    kwargs.update(overrides)
+    return _Builder().build(**kwargs)
+
+
+def test_output_node_and_bridge_inputs_exposed():
+    assert _Builder.OUTPUT_NODE is True
+    optional = _Builder.INPUT_TYPES()["optional"]
+    assert optional["imported_json"][0] == "STRING"
+    assert optional["imported_json"][1]["forceInput"] is True
+    assert optional["image"][0] == "IMAGE"
+
+
+def test_no_bridge_returns_plain_tuple():
+    result = _build()
+    assert isinstance(result, tuple)
+    assert isinstance(result[0], str)  # ideogram_json
+
+
+def test_imported_json_goes_to_ui_not_output():
+    bridge = '{"compositional_deconstruction": {"elements": [{"type": "obj", "bbox": [0, 0, 100, 100], "desc": "imported thing"}]}}'
+    out = _build(imported_json=bridge)
+    assert isinstance(out, dict) and "ui" in out and "result" in out
+    assert out["ui"]["toobusy_import"] == [bridge]
+    # The node's own output must come from elements_json (empty -> default
+    # centered subject), NOT from the imported bridge json.
+    payload = json.loads(out["result"][0])
+    descs = [el.get("desc", "") for el in payload["compositional_deconstruction"]["elements"]]
+    assert "imported thing" not in " ".join(descs)
+
+
+def test_empty_imported_json_stays_plain_tuple():
+    assert isinstance(_build(imported_json="   "), tuple)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    if failures:
+        print(f"\n{failures} test(s) failed")
+        sys.exit(1)
+    print("\nall tests passed")


### PR DESCRIPTION
## 무엇을 / 왜

운영자 요청: `Image → Ideogram Layout` 출력을 **빌더에 소켓으로 꽂고**, 리프레시 버튼으로 가져오고(복붙 없이), **원본 이미지를 백드롭으로** 깔고, **전체 큐 안 돌리고 앞단만** 실행.

## 추가

- 빌더에 optional 입력 2개: **`imported_json`**(STRING, forceInput 소켓) + **`image`**(IMAGE) — 둘 다 추가만(하위호환, 위젯 순서 영향 0).
- 빌더를 **`OUTPUT_NODE`**로 + `build()`가 실행 시 그 값을 `ui`로 프론트에 반환(이미지는 다운스케일 JPEG data URL). **자기 출력은 안 바뀜** — imported_json은 순수 프론트 브리지.
- JS **`⟳ Pull from input` 버튼**:
  1. `graphToPrompt()`로 프롬프트 떠서 **이 빌더 + 조상 노드만 추려** 부분 큐 제출 → 나머지 그래프(무거운 생성 등) 안 돎.
  2. 끝나면 `onExecuted`로 값 받아 **캔버스에 박스 로드**(기존 `payloadToState`/`applyState` 재활용) + **이미지 백드롭 세팅**(기존 `setReferenceImage`).
- 수동 빌더 / Import polished / 백드롭 기능 **0 변경**.

## 흐름

```
[Load Image] ─┬─► [Image → Ideogram Layout] ─ ideogram_json ─► imported_json
              └────────────────────────────── image ─────────► image
                                  [Ideogram Layout Builder]  ← ⟳ Pull
```
연결 → `⟳ Pull` 클릭 → 앞단만 실행 → 박스+배경 등장, 그대로 편집.

## 캐치 (정직)

- 부분 실행이어도 **Florence는 한 번은 돌아감**(값 생성 필요). 같은 이미지면 ComfyUI 캐시로 재Pull 즉시.
- **부분 큐 제출(graphToPrompt/queuePrompt)은 ComfyUI 프론트 API 의존** — 로컬에 node/ComfyUI 없어 **실제 동작은 운영자 미니PC 인앱 검증 필요**. 실패 시 캐시 적용 폴백 + 안내.

## 테스트

- 신규 `tests/test_ideogram_layout_builder.py`: OUTPUT_NODE/소켓 노출, imported_json→ui(출력 불변), 빈 값 처리. 전 스위트(11파일) green, compileall green. JS는 CI esbuild 검증.

버전/태그/Registry 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)