### PR TITLE
feat(ideogram): Layout Builder text_overlay_mode — split text out for Korean overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### Added
+- `toobusy Ideogram Layout Builder`에 **`text_overlay_mode` 토글 + `text_json` 출력** 추가 —
+  한글 반자동 파이프라인의 완결. 토글 ON이면 `ideogram_json`에서 **텍스트 요소를 빼서**(Ideogram이
+  그림/배경만 생성, 깨진 한글 안 그림) 새 `text_json` 출력으로 분리하고, 그걸 `Layout Text Overlay`에
+  물려 **크리스피한 한글**을 얹습니다. OFF면 텍스트가 이미지에 포함(영어 등 기존 동작). `text_json`은
+  항상 텍스트 전용으로 나옵니다. (출력은 뒤에 append라 기존 워크플로우 슬롯 호환.)
 - **`toobusy Layout Text Overlay`** 신규 노드: 생성된 이미지 **위에 실제 글자를 렌더**해 — Ideogram4가
   한글을 못 그려도 **크리스피한 한글 헤드라인**을 얹습니다. **인터랙티브 에디터**(이미지 배경 위에
   텍스트를 띄워 **드래그·인라인 편집·폰트크기(모서리 핸들/슬라이더)·색·정렬**) + Pillow 렌더로

--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -273,6 +273,15 @@ class IdeogramLayoutBuilder:
                         "step": 1,
                     },
                 ),
+                "text_overlay_mode": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "label_on": "split text for overlay (Korean)",
+                        "label_off": "text in image",
+                        "tooltip": "On: drop text elements from ideogram_json (Ideogram generates art only) and route them to the text_json output for Layout Text Overlay — crisp Korean instead of garbled rendering. Off: text stays in the generated image (fine for English).",
+                    },
+                ),
             },
             "optional": {
                 # Bridge inputs for the "⟳ Pull from input" button: connect an
@@ -292,8 +301,8 @@ class IdeogramLayoutBuilder:
             },
         }
 
-    RETURN_TYPES = ("STRING", "INT", "INT")
-    RETURN_NAMES = ("ideogram_json", "width", "height")
+    RETURN_TYPES = ("STRING", "INT", "INT", "STRING")
+    RETURN_NAMES = ("ideogram_json", "width", "height", "text_json")
     FUNCTION = "build"
     CATEGORY = "toobusy/Plan"
     OUTPUT_NODE = True
@@ -313,6 +322,7 @@ class IdeogramLayoutBuilder:
         include_global_palette=True,
         strict_text=True,
         reinforce_text=True,
+        text_overlay_mode=False,
         imported_json="",
         image=None,
     ):
@@ -375,16 +385,33 @@ class IdeogramLayoutBuilder:
                 global_palette, ["#111111", "#FFFFFF", "#D8C7A3"], limit=STYLE_PALETTE_MAX
             )
 
-        payload = {
-            "high_level_description": high_level_description.strip(),
-            "style_description": style_description,
-            "compositional_deconstruction": {
-                "background": background.strip(),
-                "elements": elements,
-            },
-        }
+        def _payload(elems):
+            return {
+                "high_level_description": high_level_description.strip(),
+                "style_description": style_description,
+                "compositional_deconstruction": {
+                    "background": background.strip(),
+                    "elements": elems,
+                },
+            }
 
-        result = (json.dumps(payload, ensure_ascii=False, indent=2), int(width), int(height))
+        # Korean overlay mode: split text out so Ideogram generates the art
+        # WITHOUT trying to render the (garbled) text, and the text-only payload
+        # feeds Layout Text Overlay for crisp glyphs. Off = text stays in the
+        # generation payload (fine for English).
+        text_elements = [el for el in elements if el.get("type") == "text"]
+        non_text_elements = [el for el in elements if el.get("type") != "text"]
+        if text_overlay_mode and not non_text_elements:
+            non_text_elements = [{
+                "type": "obj",
+                "bbox": [250, 250, 750, 750],
+                "desc": high_level_description.strip() or "main subject",
+            }]
+        gen_elements = non_text_elements if text_overlay_mode else elements
+
+        ideogram_json = json.dumps(_payload(gen_elements), ensure_ascii=False, indent=2)
+        text_json = json.dumps(_payload(text_elements), ensure_ascii=False, indent=2)
+        result = (ideogram_json, int(width), int(height), text_json)
 
         # Send the bridge inputs back to the frontend so the "⟳ Pull from input"
         # button can load them onto the canvas / backdrop. This never changes the

--- a/tests/test_ideogram_layout_builder.py
+++ b/tests/test_ideogram_layout_builder.py
@@ -63,6 +63,42 @@ def test_no_bridge_returns_plain_tuple():
     assert isinstance(result[0], str)  # ideogram_json
 
 
+def test_text_json_output_exposed():
+    assert _Builder.RETURN_NAMES == ("ideogram_json", "width", "height", "text_json")
+    required = _Builder.INPUT_TYPES()["required"]
+    assert required["text_overlay_mode"][0] == "BOOLEAN"
+
+
+_MIXED = json.dumps([
+    {"bbox": [100, 100, 900, 220], "text": "제목", "desc": "title"},
+    {"bbox": [100, 300, 900, 700], "desc": "a photo"},
+])
+
+
+def test_text_overlay_mode_splits_text_out():
+    out = _build(elements_json=_MIXED, text_overlay_mode=True)
+    gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
+    text = json.loads(out[3])["compositional_deconstruction"]["elements"]
+    assert "text" not in [e["type"] for e in gen]  # generation art has no text
+    assert text and all(e["type"] == "text" for e in text)  # text_json is text-only
+
+
+def test_text_overlay_off_keeps_text_in_generation():
+    out = _build(elements_json=_MIXED, text_overlay_mode=False)
+    gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
+    assert "text" in [e["type"] for e in gen]  # text stays in the image
+    # text_json is still produced (text-only) regardless of the toggle.
+    text = json.loads(out[3])["compositional_deconstruction"]["elements"]
+    assert text and all(e["type"] == "text" for e in text)
+
+
+def test_split_with_only_text_gets_fallback_obj():
+    only_text = json.dumps([{"bbox": [100, 100, 900, 220], "text": "제목", "desc": "title"}])
+    out = _build(elements_json=only_text, text_overlay_mode=True)
+    gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
+    assert gen and all(e["type"] == "obj" for e in gen)  # fallback subject so art isn't empty
+
+
 def test_imported_json_goes_to_ui_not_output():
     bridge = '{"compositional_deconstruction": {"elements": [{"type": "obj", "bbox": [0, 0, 100, 100], "desc": "imported thing"}]}}'
     out = _build(imported_json=bridge)


### PR DESCRIPTION
운영자 발주: 한글 반자동 파이프라인 완결.

## 흐름
```
Layout Builder (text_overlay_mode ON)
  ├─ ideogram_json (텍스트 제거, 그림/배경만) → Ideogram4 → 깔끔한 아트(한글 안 그림)
  └─ text_json (텍스트만) ──────────────────────────────┐
                                                        ↓
       Layout Text Overlay(image=아트, layout_json=text_json) → 크리스피 한글 최종
```

## 변경
- **`text_overlay_mode` 토글**(기본 OFF, 하위호환). ON: `ideogram_json`에서 `type:"text"` 제거 + 새 `text_json`으로 분리. OFF: 텍스트가 이미지에 포함(영어 등).
- **`text_json` 출력 추가**(텍스트 전용, 항상 생성) — 기존 출력 뒤에 append라 저장 워크플로우 슬롯 호환. 분할 후 아트 요소가 없으면 fallback subject로 생성이 비지 않게.
- 운영자가 그래프에서 **토글 하나로 "이 그래프는 한글 오버레이 방식"** 선택.

## 테스트
- 빌더 split/토글/fallback/출력노출 테스트 추가. 전 스위트(12) green, compileall green.

버전/태그/Registry 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)