### PR TITLE
fix(ideogram): show text_overlay_mode toggle in Layout Builder UI

### DIFF
--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -1356,13 +1356,20 @@ function installEditor(node) {
         (checked) => syncScene("reinforce_text", checked),
         "Off = compact JSON: rely on the text field without repeating it in desc.",
     );
+    const textOverlayField = makeCheckboxField(
+        "Split text for overlay (Korean)",
+        widget(node, "text_overlay_mode")?.value ?? false,
+        (checked) => syncScene("text_overlay_mode", checked),
+        "On: drop text from ideogram_json (Ideogram makes art only) and route it to the text_json output for Layout Text Overlay — crisp Korean. Off: text stays in the image.",
+    );
     // Map each toggle widget to its checkbox so presets can refresh the view.
     const toggleInputs = {
         include_global_palette: includePaletteField.querySelector("input"),
         strict_text: strictTextField.querySelector("input"),
         reinforce_text: reinforceTextField.querySelector("input"),
+        text_overlay_mode: textOverlayField.querySelector("input"),
     };
-    outputOptions.append(includePaletteField, strictTextField, reinforceTextField);
+    outputOptions.append(includePaletteField, strictTextField, reinforceTextField, textOverlayField);
     scene.append(outputTitle, outputOptions);
 
     // ----- Layout templates (seed a starting set of boxes) -----


### PR DESCRIPTION
운영자: "빌더에 버튼 안 보임."

원인: 빌더는 표준 위젯을 숨기고 커스텀 DOM 컨트롤을 그림. #75에서 추가한 `text_overlay_mode` BOOLEAN은 숨겨졌는데 커스텀 체크박스를 안 만들어서 안 보였음.

수정: Text & output 섹션에 **"Split text for overlay (Korean)"** 체크박스 추가(기존 토글들처럼 숨은 위젯에 바인딩). JS만 변경.

CI esbuild로 문법 검증, 동작은 운영자 인앱 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)