### PR TITLE
Fix Korean text overlay editor and split placeholders

### DIFF
--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -129,6 +129,24 @@ def _build_desc(text, desc, role="", strict_text=False, reinforce_text=True):
     return ". ".join(clauses)
 
 
+def _text_placeholder_desc(element):
+    """Keep a text box's layout footprint without asking Ideogram to draw the
+    actual lettering. The real glyphs are rendered later by Layout Text Overlay."""
+    role = str(element.get("role", "")).strip().lower()
+    desc = str(element.get("desc", "")).strip()
+    palette_hint = "empty graphic text area"
+    if role in {"headline", "subtitle", "body", "footer"}:
+        palette_hint = f"empty {role} area"
+    elif role in {"product label", "sign", "ui label", "logo"}:
+        palette_hint = f"blank {role} panel"
+    elif desc and desc.lower() not in PLACEHOLDER_DESCS:
+        palette_hint = f"blank area reserved for {desc}"
+    return (
+        f"{palette_hint}, preserve the layout space and background design, "
+        "clean surface, no letters, no words, no readable text"
+    )
+
+
 def _element_type(text, desc):
     return "text" if text else "obj"
 
@@ -400,14 +418,28 @@ class IdeogramLayoutBuilder:
         # feeds Layout Text Overlay for crisp glyphs. Off = text stays in the
         # generation payload (fine for English).
         text_elements = [el for el in elements if el.get("type") == "text"]
-        non_text_elements = [el for el in elements if el.get("type") != "text"]
-        if text_overlay_mode and not non_text_elements:
-            non_text_elements = [{
-                "type": "obj",
-                "bbox": [250, 250, 750, 750],
-                "desc": high_level_description.strip() or "main subject",
-            }]
-        gen_elements = non_text_elements if text_overlay_mode else elements
+        if text_overlay_mode:
+            gen_elements = []
+            for el in elements:
+                if el.get("type") != "text":
+                    gen_elements.append(el)
+                    continue
+                placeholder = {
+                    "type": "obj",
+                    "bbox": el["bbox"],
+                    "desc": _text_placeholder_desc(el),
+                }
+                if el.get("color_palette"):
+                    placeholder["color_palette"] = el["color_palette"]
+                gen_elements.append(placeholder)
+            if not gen_elements:
+                gen_elements = [{
+                    "type": "obj",
+                    "bbox": [250, 250, 750, 750],
+                    "desc": high_level_description.strip() or "main subject",
+                }]
+        else:
+            gen_elements = elements
 
         ideogram_json = json.dumps(_payload(gen_elements), ensure_ascii=False, indent=2)
         text_json = json.dumps(_payload(text_elements), ensure_ascii=False, indent=2)

--- a/js/toobusy_layout_text_overlay.js
+++ b/js/toobusy_layout_text_overlay.js
@@ -7,18 +7,24 @@ import { app } from "../../scripts/app.js";
 
 const NODE_CLASS = "ToobusyLayoutTextOverlay";
 const ACCENT = "#7fc8ff";
+const FONT_OPTIONS = [
+    ["malgun", "Malgun Gothic"],
+    ["serif", "Serif"],
+    ["mono", "Mono"],
+];
 
 function injectStyle() {
     if (document.getElementById("toobusy-overlay-style")) return;
     const style = document.createElement("style");
     style.id = "toobusy-overlay-style";
     style.textContent = `
-    .tb-overlay { display:flex; flex-direction:column; gap:6px; width:100%; font-family:sans-serif; }
+    .tb-overlay { display:flex; flex-direction:column; gap:6px; width:100%; height:420px; min-height:360px; font-family:sans-serif; }
     .tb-overlay-bar { display:flex; flex-wrap:wrap; gap:6px; align-items:center; }
     .tb-overlay-bar button { background:#2a2f37; color:#cfd6de; border:1px solid #3a414b; border-radius:5px; padding:3px 8px; cursor:pointer; font-size:11px; }
     .tb-overlay-bar button:hover { border-color:${ACCENT}; }
     .tb-overlay-bar label { color:#9aa4b0; font-size:11px; display:flex; gap:4px; align-items:center; }
-    .tb-overlay-stage { position:relative; width:100%; background:#15191e center/contain no-repeat; border:1px solid #2d3642; border-radius:6px; overflow:hidden; user-select:none; }
+    .tb-overlay-bar select { background:#1f252c; color:#cfd6de; border:1px solid #3a414b; border-radius:5px; padding:2px 5px; font-size:11px; }
+    .tb-overlay-stage { position:relative; flex:1 1 auto; min-height:260px; width:100%; background:#15191e center/contain no-repeat; border:1px solid #2d3642; border-radius:6px; overflow:hidden; user-select:none; }
     .tb-overlay-hint { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; color:#6b7785; font-size:12px; text-align:center; padding:12px; }
     .tb-text { position:absolute; box-sizing:border-box; cursor:move; outline:1px dashed transparent; line-height:1.1; white-space:pre-wrap; word-break:break-word; }
     .tb-text.sel { outline:1px dashed ${ACCENT}; }
@@ -32,12 +38,20 @@ function clamp(v, lo, hi) {
     return Math.max(lo, Math.min(hi, v));
 }
 
+function hideWidget(widget) {
+    if (!widget) return;
+    widget.type = "hidden";
+    widget.computeSize = () => [0, -4];
+    widget.hidden = true;
+}
+
 function install(node) {
     injectStyle();
     const overlayWidget = node.widgets?.find((w) => w.name === "overlay_data");
 
     let items = [];
     let selected = -1;
+    let editingIndex = -1;
     let backdropAspect = 16 / 9;
 
     function loadItems() {
@@ -70,24 +84,31 @@ function install(node) {
     stage.appendChild(hint);
 
     root.append(bar, stage);
+    node._toobusyOverlayRoot = root;
 
     function stageSize() {
         const w = stage.clientWidth || 320;
-        return { w, h: w / backdropAspect };
+        const h = stage.clientHeight || Math.max(260, w / backdropAspect);
+        return { w, h };
     }
 
     function applyStageHeight() {
-        const { h } = stageSize();
-        stage.style.height = `${Math.max(80, Math.round(h))}px`;
+        const w = stage.clientWidth || 320;
+        stage.style.minHeight = `${Math.max(260, Math.round(w / backdropAspect))}px`;
     }
 
     function renderItems() {
+        if (editingIndex >= 0) {
+            syncToolbar();
+            return;
+        }
         // Remove old text nodes (keep hint).
         stage.querySelectorAll(".tb-text").forEach((el) => el.remove());
         const { w, h } = stageSize();
         hint.style.display = items.length ? "none" : "flex";
 
         items.forEach((item, index) => {
+            if (index === editingIndex) return;
             const el = document.createElement("div");
             el.className = "tb-text" + (index === selected ? " sel" : "");
             el.style.left = `${clamp(item.x ?? 0, 0, 1) * 100}%`;
@@ -95,17 +116,34 @@ function install(node) {
             el.style.width = `${clamp(item.w ?? 0.5, 0.02, 1) * 100}%`;
             el.style.fontSize = `${(item.fontSize ?? 0.08) * h}px`;
             el.style.color = item.color || "#FFFFFF";
+            el.style.fontFamily = cssFontFamily(item.fontFamily);
             el.style.textAlign = item.align || "center";
             el.style.fontWeight = "700";
             el.style.textShadow = `0 0 ${Math.max(1, (item.strokeWidth ?? 3))}px ${item.stroke || "#000"}, 0 1px 2px ${item.stroke || "#000"}`;
             el.textContent = item.text || "";
 
             el.addEventListener("pointerdown", (e) => startDrag(e, index, el));
-            el.addEventListener("dblclick", () => beginEdit(el, index));
+            el.addEventListener("dblclick", (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                beginEdit(el, index);
+            });
             el.addEventListener("blur", () => {
                 el.contentEditable = "false";
                 item.text = el.textContent;
+                editingIndex = -1;
                 persist();
+                renderItems();
+            });
+            el.addEventListener("keydown", (e) => {
+                if (e.key === "Escape") {
+                    e.preventDefault();
+                    editingIndex = -1;
+                    renderItems();
+                } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                    e.preventDefault();
+                    el.blur();
+                }
             });
 
             const handle = document.createElement("div");
@@ -120,9 +158,16 @@ function install(node) {
 
     function beginEdit(el, index) {
         selected = index;
+        editingIndex = index;
+        el.classList.add("sel");
         el.contentEditable = "true";
         el.focus();
-        renderItems();
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        syncToolbar();
     }
 
     function startDrag(event, index, el) {
@@ -130,6 +175,7 @@ function install(node) {
         event.preventDefault();
         event.stopPropagation();
         selected = index;
+        editingIndex = -1;
         const { w, h } = stageSize();
         const startX = event.clientX;
         const startY = event.clientY;
@@ -155,6 +201,7 @@ function install(node) {
         event.preventDefault();
         event.stopPropagation();
         selected = index;
+        editingIndex = -1;
         const { h } = stageSize();
         const startY = event.clientY;
         const item = items[index];
@@ -176,8 +223,9 @@ function install(node) {
     const addBtn = document.createElement("button");
     addBtn.textContent = "＋ Text";
     addBtn.onclick = () => {
-        items.push({ text: "텍스트", x: 0.3, y: 0.45, w: 0.4, h: 0.1, fontSize: 0.07, color: "#FFFFFF", stroke: "#000000", strokeWidth: 3, align: "center" });
+        items.push({ text: "텍스트", x: 0.3, y: 0.45, w: 0.4, h: 0.1, fontSize: 0.07, color: "#FFFFFF", stroke: "#000000", strokeWidth: 3, align: "center", fontFamily: "malgun" });
         selected = items.length - 1;
+        editingIndex = -1;
         persist();
         renderItems();
     };
@@ -188,6 +236,7 @@ function install(node) {
         if (selected < 0) return;
         items.splice(selected, 1);
         selected = -1;
+        editingIndex = -1;
         persist();
         renderItems();
     };
@@ -220,6 +269,23 @@ function install(node) {
     colorInput.onchange = persist;
     colorLabel.appendChild(colorInput);
 
+    const fontLabel = document.createElement("label");
+    fontLabel.textContent = "font";
+    const fontSelect = document.createElement("select");
+    for (const [value, label] of FONT_OPTIONS) {
+        const option = document.createElement("option");
+        option.value = value;
+        option.textContent = label;
+        fontSelect.appendChild(option);
+    }
+    fontSelect.onchange = () => {
+        if (selected < 0) return;
+        items[selected].fontFamily = fontSelect.value;
+        persist();
+        renderItems();
+    };
+    fontLabel.appendChild(fontSelect);
+
     const alignBtn = document.createElement("button");
     alignBtn.textContent = "align: center";
     alignBtn.onclick = () => {
@@ -232,7 +298,7 @@ function install(node) {
         renderItems();
     };
 
-    bar.append(addBtn, delBtn, sizeLabel, colorLabel, alignBtn);
+    bar.append(addBtn, delBtn, sizeLabel, colorLabel, fontLabel, alignBtn);
 
     function syncToolbar() {
         const item = selected >= 0 ? items[selected] : null;
@@ -240,10 +306,12 @@ function install(node) {
         delBtn.disabled = !has;
         sizeInput.disabled = !has;
         colorInput.disabled = !has;
+        fontSelect.disabled = !has;
         alignBtn.disabled = !has;
         if (item) {
             sizeInput.value = String((item.fontSize ?? 0.08) * 100);
             colorInput.value = item.color || "#ffffff";
+            fontSelect.value = item.fontFamily || "malgun";
             alignBtn.textContent = `align: ${item.align || "center"}`;
         }
     }
@@ -252,12 +320,24 @@ function install(node) {
     stage.addEventListener("pointerdown", (e) => {
         if (e.target === stage || e.target === hint) {
             selected = -1;
+            editingIndex = -1;
             renderItems();
         }
     });
 
+    function cssFontFamily(value) {
+        const key = String(value || "malgun").toLowerCase();
+        if (key === "serif") return `"Batang", "Noto Serif CJK KR", Georgia, serif`;
+        if (key === "mono") return `"D2Coding", Consolas, monospace`;
+        return `"Malgun Gothic", "Apple SD Gothic Neo", "Noto Sans CJK KR", sans-serif`;
+    }
+
     if (node.addDOMWidget) {
-        node.addDOMWidget("overlay_editor", "toobusy_overlay", root, { serialize: false });
+        node.addDOMWidget("overlay_editor", "toobusy_overlay", root, {
+            serialize: false,
+            getMinHeight: () => 360,
+            getHeight: () => root.offsetHeight || 420,
+        });
     }
 
     // Receive backdrop image + seed items after a run.
@@ -302,6 +382,28 @@ function install(node) {
 app.registerExtension({
     name: "toobusy.layoutTextOverlay",
     async nodeCreated(node) {
-        if (node.comfyClass === NODE_CLASS) install(node);
+        if (node.comfyClass !== NODE_CLASS) return;
+        const overlayWidget = node.widgets?.find((w) => w.name === "overlay_data");
+        hideWidget(overlayWidget);
+        install(node);
+        const syncHeight = () => {
+            const root = node._toobusyOverlayRoot;
+            if (root) root.style.height = `${Math.max(360, Math.round((node.size?.[1] || 620) - 150))}px`;
+        };
+        if (!node.size || node.size[1] < 560) node.setSize?.([Math.max(node.size?.[0] || 760, 760), 620]);
+        syncHeight();
+        const prevResize = node.onResize;
+        node.onResize = function () {
+            const result = prevResize?.apply(this, arguments);
+            syncHeight();
+            return result;
+        };
+        const prevConfigure = node.onConfigure;
+        node.onConfigure = function () {
+            const result = prevConfigure?.apply(this, arguments);
+            requestAnimationFrame(syncHeight);
+            return result;
+        };
+        requestAnimationFrame(syncHeight);
     },
 });

--- a/layout_text_overlay_node/layout_text_overlay.py
+++ b/layout_text_overlay_node/layout_text_overlay.py
@@ -41,11 +41,21 @@ def _hex_rgb(value, default=(255, 255, 255)):
     return default
 
 
-def _font(size):
+FONT_CANDIDATES = {
+    "malgun": ("malgun.ttf", "malgunsl.ttf", "arial.ttf", "DejaVuSans.ttf"),
+    "gothic": ("malgun.ttf", "arial.ttf", "DejaVuSans.ttf"),
+    "serif": ("batang.ttc", "gulim.ttc", "Georgia.ttf", "Times New Roman.ttf", "DejaVuSerif.ttf"),
+    "mono": ("consola.ttf", "D2Coding.ttf", "DejaVuSansMono.ttf"),
+}
+
+
+def _font(size, family="malgun"):
     """malgun first so Korean renders with real glyphs on Windows."""
     from PIL import ImageFont
 
-    for name in ("malgun.ttf", "arial.ttf", "DejaVuSans.ttf"):
+    family_key = str(family or "malgun").strip().lower()
+    candidates = FONT_CANDIDATES.get(family_key, FONT_CANDIDATES["malgun"])
+    for name in candidates:
         try:
             return ImageFont.truetype(name, max(8, int(size)))
         except Exception:
@@ -92,6 +102,7 @@ def seed_items_from_layout(layout_json):
             "stroke": "#000000",
             "strokeWidth": 3,
             "align": "center",
+            "fontFamily": "malgun",
         })
     return items
 
@@ -121,11 +132,11 @@ def _wrap(draw, text, font, max_width):
     return out_lines or [""]
 
 
-def _fit_font_size(draw, text, box_w, box_h, max_size):
+def _fit_font_size(draw, text, box_w, box_h, max_size, family="malgun"):
     """Largest font size (<= max_size) whose wrapped text fits the box."""
     size = max(8, int(max_size))
     while size > 8:
-        font = _font(size)
+        font = _font(size, family)
         lines = _wrap(draw, text, font, box_w)
         line_h = (draw.textbbox((0, 0), "Ag", font=font)[3]) * 1.15
         if len(lines) * line_h <= box_h and all(draw.textlength(l, font=font) <= box_w for l in lines):
@@ -146,11 +157,11 @@ def _draw_item(draw, item, width, height, font_scale):
     # fontSize is a fraction of image height; 0 = auto-fit to the box.
     size_frac = float(item.get("fontSize") or 0)
     if size_frac <= 0:
-        size = _fit_font_size(draw, text, box_w, box_h, max_size=box_h)
+        size = _fit_font_size(draw, text, box_w, box_h, max_size=box_h, family=item.get("fontFamily", "malgun"))
     else:
         size = int(size_frac * height)
     size = max(8, int(size * float(font_scale)))
-    font = _font(size)
+    font = _font(size, item.get("fontFamily", "malgun"))
 
     color = _hex_rgb(item.get("color"), (255, 255, 255))
     stroke = _hex_rgb(item.get("stroke"), (0, 0, 0))

--- a/tests/test_ideogram_layout_builder.py
+++ b/tests/test_ideogram_layout_builder.py
@@ -79,7 +79,12 @@ def test_text_overlay_mode_splits_text_out():
     out = _build(elements_json=_MIXED, text_overlay_mode=True)
     gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
     text = json.loads(out[3])["compositional_deconstruction"]["elements"]
-    assert "text" not in [e["type"] for e in gen]  # generation art has no text
+    assert "text" not in [e["type"] for e in gen]  # generation art has no literal text
+    assert len(gen) == 2  # text bbox stays as a placeholder, so structure remains
+    placeholder = gen[0]
+    assert placeholder["type"] == "obj"
+    assert placeholder["bbox"] == [100, 100, 220, 900]
+    assert "no readable text" in placeholder["desc"]
     assert text and all(e["type"] == "text" for e in text)  # text_json is text-only
 
 
@@ -96,7 +101,8 @@ def test_split_with_only_text_gets_fallback_obj():
     only_text = json.dumps([{"bbox": [100, 100, 900, 220], "text": "제목", "desc": "title"}])
     out = _build(elements_json=only_text, text_overlay_mode=True)
     gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
-    assert gen and all(e["type"] == "obj" for e in gen)  # fallback subject so art isn't empty
+    assert gen and all(e["type"] == "obj" for e in gen)
+    assert gen[0]["bbox"] == [100, 100, 220, 900]  # original title space is preserved
 
 
 def test_imported_json_goes_to_ui_not_output():

--- a/tests/test_layout_text_overlay.py
+++ b/tests/test_layout_text_overlay.py
@@ -56,6 +56,7 @@ def test_seed_only_text_elements_and_normalize():
     assert abs(title["w"] - 0.504) < 1e-6 and abs(title["h"] - 0.114) < 1e-6
     # fontSize is a fraction of image height (~0.8 * box height) so the seed fills the box.
     assert abs(title["fontSize"] - round(0.114 * 0.8, 4)) < 1e-6
+    assert title["fontFamily"] == "malgun"
 
 
 def test_seed_handles_garbage_json():
@@ -101,6 +102,33 @@ def test_render_with_explicit_items():
     out = _mod.render_overlay(image, overlay, "", font_scale=1.0)
     assert tuple(out.shape) == (1, 100, 100, 3)
     assert float(out[..., 0].max()) > 0.5  # red channel lit by the red text
+
+
+def test_font_family_is_forwarded_to_font_loader():
+    calls = []
+    original = _mod._font
+    try:
+        def fake_font(size, family="malgun"):
+            calls.append(family)
+            return original(size, family)
+
+        _mod._font = fake_font
+        try:
+            import torch
+            import PIL  # noqa: F401
+        except ImportError:
+            print("SKIP test_font_family_is_forwarded_to_font_loader (no torch/PIL)")
+            return
+        import json as _json
+
+        image = torch.zeros(1, 80, 160, 3)
+        overlay = _json.dumps({"items": [
+            {"text": "폰트", "x": 0.1, "y": 0.1, "w": 0.8, "h": 0.5, "fontSize": 0.2, "fontFamily": "serif"},
+        ]})
+        _mod.render_overlay(image, overlay, "", font_scale=1.0)
+        assert "serif" in calls
+    finally:
+        _mod._font = original
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve Korean text layout boxes as no-letter placeholders when Builder splits text for overlay
- keep the Layout Text Overlay canvas visible on node creation/resizes
- fix inline text editing so the DOM editor is not destroyed on focus
- add selected-item font family support in the JS editor and Python renderer

## Tests
- bundled node --check for js/*.js
- python -m compileall -q .
- python tests/test_ideogram_layout_builder.py
- python tests/test_layout_text_overlay.py

## Release
- no version bump
- no tag
- no Registry publish