### PR TITLE
Split only Hangul text for overlay

### DIFF
--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -129,6 +129,22 @@ def _build_desc(text, desc, role="", strict_text=False, reinforce_text=True):
     return ". ".join(clauses)
 
 
+def _has_hangul(value):
+    for char in str(value or ""):
+        code = ord(char)
+        if 0xAC00 <= code <= 0xD7A3 or 0x1100 <= code <= 0x11FF or 0x3130 <= code <= 0x318F:
+            return True
+    return False
+
+
+def _is_split_overlay_text(element):
+    return bool(element.get("_split_for_overlay"))
+
+
+def _public_element(element):
+    return {key: value for key, value in element.items() if not key.startswith("_")}
+
+
 def _text_placeholder_desc(element):
     """Keep a text box's layout footprint without asking Ideogram to draw the
     actual lettering. The real glyphs are rendered later by Layout Text Overlay."""
@@ -362,6 +378,7 @@ class IdeogramLayoutBuilder:
             element = {"type": element_type, "bbox": ideogram_bbox}
             if element_type == "text":
                 element["text"] = text
+                element["_split_for_overlay"] = _has_hangul(text)
             element["desc"] = _build_desc(
                 text, desc, role=role, strict_text=strict_text, reinforce_text=reinforce_text
             )
@@ -416,19 +433,21 @@ class IdeogramLayoutBuilder:
                 "style_description": style,
                 "compositional_deconstruction": {
                     "background": comp_background,
-                    "elements": elems,
+                    "elements": [_public_element(el) for el in elems],
                 },
             }
 
-        # Korean overlay mode: split text out so Ideogram generates the art
-        # WITHOUT trying to render the (garbled) text, and the text-only payload
-        # feeds Layout Text Overlay for crisp glyphs. Off = text stays in the
-        # generation payload (fine for English).
-        text_elements = [el for el in elements if el.get("type") == "text"]
+        # Korean overlay mode: split Hangul text out so Ideogram generates the
+        # art WITHOUT trying to render the (garbled) Korean glyphs. Non-Hangul
+        # text stays in the generation payload so labels like "LTX2.3" remain.
+        text_elements = [
+            el for el in elements
+            if _is_split_overlay_text(el)
+        ]
         if text_overlay_mode:
             gen_elements = []
             for el in elements:
-                if el.get("type") != "text":
+                if not _is_split_overlay_text(el):
                     gen_elements.append(el)
                     continue
                 placeholder = {

--- a/tests/test_ideogram_layout_builder.py
+++ b/tests/test_ideogram_layout_builder.py
@@ -69,8 +69,14 @@ def test_text_json_output_exposed():
     assert required["text_overlay_mode"][0] == "BOOLEAN"
 
 
+def test_hangul_detection_marks_overlay_split_only():
+    assert _mod._has_hangul("제목") is True
+    assert _mod._has_hangul("LTX2.3") is False
+
+
 _MIXED = json.dumps([
     {"bbox": [100, 100, 900, 220], "text": "제목", "desc": "title"},
+    {"bbox": [100, 235, 360, 285], "text": "LTX2.3", "desc": "model label"},
     {"bbox": [100, 300, 900, 700], "desc": "a photo"},
 ])
 
@@ -79,18 +85,22 @@ def test_text_overlay_mode_splits_text_out():
     out = _build(elements_json=_MIXED, text_overlay_mode=True)
     gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
     text = json.loads(out[3])["compositional_deconstruction"]["elements"]
-    assert "text" not in [e["type"] for e in gen]  # generation art has no literal text
-    assert len(gen) == 2  # text bbox stays as a placeholder, so structure remains
+    assert len(gen) == 3  # Hangul bbox stays as a placeholder, non-Hangul text remains
     placeholder = gen[0]
     assert placeholder["type"] == "obj"
     assert placeholder["bbox"] == [100, 100, 220, 900]
+    assert gen[1]["type"] == "text"
+    assert gen[1]["text"] == "LTX2.3"
     assert "no readable text" in placeholder["desc"]
     assert "no Korean characters" in placeholder["desc"]
     generation_payload = out[0]
     assert "제목" not in generation_payload
+    assert "LTX2.3" in generation_payload
+    assert "_split_for_overlay" not in generation_payload
+    assert "_split_for_overlay" not in out[3]
     assert "title" not in placeholder["desc"].lower()
     assert "Generate artwork only" in generation_payload
-    assert text and all(e["type"] == "text" for e in text)  # text_json is text-only
+    assert [e["text"] for e in text] == ["제목"]  # text_json is Hangul-overlay only
 
 
 def test_text_overlay_off_keeps_text_in_generation():


### PR DESCRIPTION
## Summary
- mark Hangul text structurally while Layout Builder builds elements
- split only Hangul text to `text_json`; keep non-Hangul labels like `LTX2.3` in `ideogram_json`
- strip private split metadata before emitting JSON

## Notes
This does not pixel-edit an existing image. Mixed English+Hangul in one text bbox still needs upstream separation if the English substring must remain generated while only the Hangul substring moves to overlay.

## Tests
- python tests/test_ideogram_layout_builder.py
- python -m compileall -q ideogram_layout_builder
- sample output check with unicode escapes: generation keeps English, removes Hangul; text_json keeps Hangul only

## Release
- no version bump
- no tag
- no Registry publish