### PR TITLE
Split mixed Hangul text into sub-bboxes

### DIFF
--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -137,6 +137,127 @@ def _has_hangul(value):
     return False
 
 
+def _is_ascii_label_char(char):
+    return char.isascii() and (char.isalnum() or char in ".+-_:/")
+
+
+def _char_width_weight(char):
+    if _has_hangul(char):
+        return 1.0
+    if char.isspace():
+        return 0.35
+    if char.isascii() and char.isalnum():
+        return 0.62
+    return 0.35
+
+
+def _clean_split_run(text, keep):
+    value = str(text or "")
+    if keep == "gen":
+        value = re.sub(r"\([^A-Za-z0-9]*\)", "", value)
+        value = value.strip(" -_:/|()[]")
+    else:
+        value = re.sub(r"\(\s*([^)]+?)\s*\)", r"\1", value)
+        value = value.strip(" -_:/|()[]")
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _join_split_text(left, right):
+    if not left:
+        return right
+    if not right:
+        return left
+    if _has_hangul(left[-1]) and right[0].isdigit():
+        return f"{left} {right}"
+    if left[-1].isdigit() and _has_hangul(right[0]):
+        return f"{left}{right}"
+    if left[-1].isascii() and left[-1].isalnum() and right[0].isascii() and right[0].isalnum():
+        return f"{left} {right}"
+    return f"{left}{right}"
+
+
+def _merge_adjacent_runs(runs):
+    merged = []
+    for run in runs:
+        if merged and merged[-1]["kind"] == run["kind"]:
+            merged[-1]["text"] = _join_split_text(merged[-1]["text"], run["text"])
+            merged[-1]["bbox"][2] = max(merged[-1]["bbox"][2], run["bbox"][2])
+            merged[-1]["bbox"][3] = max(merged[-1]["bbox"][3], run["bbox"][3])
+        else:
+            merged.append(dict(run))
+    return merged
+
+
+def _split_mixed_hangul_runs(text, bbox):
+    """Split a mixed label into approximate horizontal sub-bboxes.
+
+    The layout JSON only gives one bbox for a full text string. When a label
+    mixes English/product text and Hangul, estimate sub-boxes by character width
+    so generation can keep the English part while overlay receives only Hangul.
+    """
+    original = str(text or "").strip()
+    if not _has_hangul(original):
+        return []
+
+    y_min, x_min, y_max, x_max = bbox
+    total_width = max(1, x_max - x_min)
+    total_weight = sum(_char_width_weight(char) for char in original) or 1.0
+    cursor = float(x_min)
+    runs = []
+    current_kind = None
+    current_text = []
+    current_start = cursor
+
+    def char_kind(char):
+        if _has_hangul(char):
+            return "overlay"
+        if _is_ascii_label_char(char):
+            return "gen"
+        return current_kind or "overlay"
+
+    def flush(end_x):
+        nonlocal current_kind, current_text, current_start
+        if not current_text or not current_kind:
+            current_text = []
+            current_kind = None
+            current_start = end_x
+            return
+        run_kind = current_kind
+        has_ascii_word = any(char.isascii() and char.isalpha() for char in current_text)
+        if run_kind == "gen" and not has_ascii_word:
+            run_kind = "overlay"
+        cleaned = _clean_split_run("".join(current_text), run_kind)
+        if cleaned:
+            run_x0 = _clamp_int(current_start)
+            run_x1 = _clamp_int(end_x)
+            if run_x1 - run_x0 < MIN_BOX_SIZE:
+                run_x1 = min(1000, run_x0 + MIN_BOX_SIZE)
+            runs.append({
+                "kind": run_kind,
+                "text": cleaned,
+                "bbox": [y_min, run_x0, y_max, run_x1],
+            })
+        current_text = []
+        current_kind = None
+        current_start = end_x
+
+    for char in original:
+        width = total_width * (_char_width_weight(char) / total_weight)
+        next_cursor = cursor + width
+        kind = char_kind(char)
+        if current_kind is None:
+            current_kind = kind
+            current_start = cursor
+        elif kind != current_kind:
+            flush(cursor)
+            current_kind = kind
+            current_start = cursor
+        current_text.append(char)
+        cursor = next_cursor
+    flush(float(x_max))
+    return _merge_adjacent_runs(runs)
+
+
 def _is_split_overlay_text(element):
     return bool(element.get("_split_for_overlay"))
 
@@ -379,6 +500,8 @@ class IdeogramLayoutBuilder:
             if element_type == "text":
                 element["text"] = text
                 element["_split_for_overlay"] = _has_hangul(text)
+                if element["_split_for_overlay"]:
+                    element["_split_runs"] = _split_mixed_hangul_runs(text, ideogram_bbox)
             element["desc"] = _build_desc(
                 text, desc, role=role, strict_text=strict_text, reinforce_text=reinforce_text
             )
@@ -420,10 +543,10 @@ class IdeogramLayoutBuilder:
             comp_background = background.strip()
             if suppress_text:
                 text_policy = (
-                    "Generate artwork only. Leave all reserved panels blank. "
-                    "Do not render visible text, typography, letters, words, "
-                    "logos, symbols, subtitles, captions, or Korean characters; "
-                    "real text will be added later by a separate overlay."
+                    "Preserve non-Korean labels and product names that remain "
+                    "in the layout. For reserved Korean overlay panels only, "
+                    "leave the area blank and do not render Hangul or Korean "
+                    "characters; Korean text will be added later by a separate overlay."
                 )
                 high_level = f"{high_level} {text_policy}".strip()
                 style["aesthetics"] = f"{style.get('aesthetics', '').strip()} {text_policy}".strip()
@@ -440,24 +563,58 @@ class IdeogramLayoutBuilder:
         # Korean overlay mode: split Hangul text out so Ideogram generates the
         # art WITHOUT trying to render the (garbled) Korean glyphs. Non-Hangul
         # text stays in the generation payload so labels like "LTX2.3" remain.
-        text_elements = [
-            el for el in elements
-            if _is_split_overlay_text(el)
-        ]
+        text_elements = []
+        for el in elements:
+            if not _is_split_overlay_text(el):
+                continue
+            overlay_runs = [run for run in el.get("_split_runs", []) if run["kind"] == "overlay"]
+            if not overlay_runs:
+                text_elements.append(el)
+                continue
+            for run in overlay_runs:
+                overlay_el = {
+                    "type": "text",
+                    "bbox": run["bbox"],
+                    "text": run["text"],
+                    "desc": _build_desc(run["text"], "Korean overlay text", strict_text=strict_text, reinforce_text=reinforce_text),
+                }
+                if el.get("color_palette"):
+                    overlay_el["color_palette"] = el["color_palette"]
+                text_elements.append(overlay_el)
         if text_overlay_mode:
             gen_elements = []
             for el in elements:
                 if not _is_split_overlay_text(el):
                     gen_elements.append(el)
                     continue
-                placeholder = {
-                    "type": "obj",
-                    "bbox": el["bbox"],
-                    "desc": _text_placeholder_desc(el),
-                }
-                if el.get("color_palette"):
-                    placeholder["color_palette"] = el["color_palette"]
-                gen_elements.append(placeholder)
+                split_runs = el.get("_split_runs", [])
+                if not split_runs:
+                    placeholder = {
+                        "type": "obj",
+                        "bbox": el["bbox"],
+                        "desc": _text_placeholder_desc(el),
+                    }
+                    if el.get("color_palette"):
+                        placeholder["color_palette"] = el["color_palette"]
+                    gen_elements.append(placeholder)
+                    continue
+                for run in split_runs:
+                    if run["kind"] == "gen":
+                        gen_el = {
+                            "type": "text",
+                            "bbox": run["bbox"],
+                            "text": run["text"],
+                            "desc": _build_desc(run["text"], "non-Korean label text", strict_text=strict_text, reinforce_text=reinforce_text),
+                        }
+                    else:
+                        gen_el = {
+                            "type": "obj",
+                            "bbox": run["bbox"],
+                            "desc": _text_placeholder_desc(el),
+                        }
+                    if el.get("color_palette"):
+                        gen_el["color_palette"] = el["color_palette"]
+                    gen_elements.append(gen_el)
             if not gen_elements:
                 gen_elements = [{
                     "type": "obj",

--- a/tests/test_ideogram_layout_builder.py
+++ b/tests/test_ideogram_layout_builder.py
@@ -74,8 +74,15 @@ def test_hangul_detection_marks_overlay_split_only():
     assert _mod._has_hangul("LTX2.3") is False
 
 
+def test_mixed_hangul_runs_keep_digits_with_overlay():
+    runs = _mod._split_mixed_hangul_runs("첫, 중간, 끝 3키프레임", [100, 100, 200, 900])
+    overlay_text = "".join(run["text"] for run in runs if run["kind"] == "overlay")
+    assert "3" in overlay_text
+    assert "키프레임" in overlay_text
+
+
 _MIXED = json.dumps([
-    {"bbox": [100, 100, 900, 220], "text": "제목", "desc": "title"},
+    {"bbox": [100, 100, 900, 220], "text": "LTX2.3 두두등장!", "desc": "title"},
     {"bbox": [100, 235, 360, 285], "text": "LTX2.3", "desc": "model label"},
     {"bbox": [100, 300, 900, 700], "desc": "a photo"},
 ])
@@ -85,22 +92,26 @@ def test_text_overlay_mode_splits_text_out():
     out = _build(elements_json=_MIXED, text_overlay_mode=True)
     gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
     text = json.loads(out[3])["compositional_deconstruction"]["elements"]
-    assert len(gen) == 3  # Hangul bbox stays as a placeholder, non-Hangul text remains
-    placeholder = gen[0]
+    assert len(gen) == 4  # mixed label becomes English text + Korean placeholder
+    assert gen[0]["type"] == "text"
+    assert gen[0]["text"] == "LTX2.3"
+    placeholder = gen[1]
     assert placeholder["type"] == "obj"
-    assert placeholder["bbox"] == [100, 100, 220, 900]
-    assert gen[1]["type"] == "text"
-    assert gen[1]["text"] == "LTX2.3"
+    assert gen[0]["bbox"][1] < placeholder["bbox"][1]  # English run is left of Hangul run
+    assert gen[2]["type"] == "text"
+    assert gen[2]["text"] == "LTX2.3"
     assert "no readable text" in placeholder["desc"]
     assert "no Korean characters" in placeholder["desc"]
     generation_payload = out[0]
-    assert "제목" not in generation_payload
+    assert "두두등장" not in generation_payload
     assert "LTX2.3" in generation_payload
     assert "_split_for_overlay" not in generation_payload
+    assert "_split_runs" not in generation_payload
     assert "_split_for_overlay" not in out[3]
     assert "title" not in placeholder["desc"].lower()
-    assert "Generate artwork only" in generation_payload
-    assert [e["text"] for e in text] == ["제목"]  # text_json is Hangul-overlay only
+    assert "Preserve non-Korean labels" in generation_payload
+    assert [e["text"] for e in text] == ["두두등장!"]  # text_json is Hangul-overlay only
+    assert text[0]["bbox"][1] > gen[0]["bbox"][1]  # overlay run gets its own sub-bbox
 
 
 def test_text_overlay_off_keeps_text_in_generation():
@@ -117,7 +128,7 @@ def test_split_with_only_text_gets_fallback_obj():
     out = _build(elements_json=only_text, text_overlay_mode=True)
     gen = json.loads(out[0])["compositional_deconstruction"]["elements"]
     assert gen and all(e["type"] == "obj" for e in gen)
-    assert gen[0]["bbox"] == [100, 100, 220, 900]  # original title space is preserved
+    assert gen[0]["bbox"] == [100, 100, 220, 900]  # all-Korean title keeps its full space
 
 
 def test_imported_json_goes_to_ui_not_output():


### PR DESCRIPTION
## Summary
- split mixed English/Hangul text into estimated horizontal sub-bboxes
- keep non-Korean runs like `LTX2.3`, `ComfyUI`, `First Frame` in `ideogram_json`
- send only Hangul-facing runs like `두두등장!`, `시작 프레임` to `text_json`
- merge adjacent overlay runs so Korean sentences remain editable as one item
- narrow the text suppression prompt so non-Korean labels are preserved

## Notes
Sub-bboxes are estimated from character-width weights because the upstream layout JSON has no per-span coordinates. This is not OCR/font-metric exact, but it avoids losing English labels when a mixed text box contains Hangul.

## Tests
- python tests/test_ideogram_layout_builder.py
- python -m compileall -q ideogram_layout_builder
- sample output check for `LTX2.3 두두등장!` and Korean summary text

## Release
- no version bump
- no tag
- no Registry publish