### PR TITLE
Orient mixed text split and widen builder canvas

### DIFF
--- a/ideogram_layout_builder/nodes.py
+++ b/ideogram_layout_builder/nodes.py
@@ -188,21 +188,50 @@ def _merge_adjacent_runs(runs):
     return merged
 
 
+def _split_axis(text, bbox):
+    y_min, x_min, y_max, x_max = _normalize_bbox(bbox)
+    width = max(1, x_max - x_min)
+    height = max(1, y_max - y_min)
+    if "\n" in str(text or ""):
+        return "y"
+    if width / height >= 2.1 and height >= 180 and len(str(text or "")) >= 18:
+        return "y"
+    return "x"
+
+
+def _run_bbox(axis, y_min, x_min, y_max, x_max, start, end):
+    if axis == "y":
+        run_y0 = _clamp_int(start)
+        run_y1 = _clamp_int(end)
+        if run_y1 - run_y0 < MIN_BOX_SIZE:
+            run_y1 = min(1000, run_y0 + MIN_BOX_SIZE)
+        return [run_y0, x_min, run_y1, x_max]
+    run_x0 = _clamp_int(start)
+    run_x1 = _clamp_int(end)
+    if run_x1 - run_x0 < MIN_BOX_SIZE:
+        run_x1 = min(1000, run_x0 + MIN_BOX_SIZE)
+    return [y_min, run_x0, y_max, run_x1]
+
+
 def _split_mixed_hangul_runs(text, bbox):
-    """Split a mixed label into approximate horizontal sub-bboxes.
+    """Split a mixed label into approximate sub-bboxes.
 
     The layout JSON only gives one bbox for a full text string. When a label
-    mixes English/product text and Hangul, estimate sub-boxes by character width
-    so generation can keep the English part while overlay receives only Hangul.
+    mixes English/product text and Hangul, estimate horizontal or vertical
+    sub-boxes so generation can keep the English part while overlay receives
+    only Hangul.
     """
     original = str(text or "").strip()
     if not _has_hangul(original):
         return []
 
-    y_min, x_min, y_max, x_max = bbox
-    total_width = max(1, x_max - x_min)
+    y_min, x_min, y_max, x_max = _normalize_bbox(bbox)
+    axis = _split_axis(original, bbox)
+    span_start = y_min if axis == "y" else x_min
+    span_end = y_max if axis == "y" else x_max
+    total_span = max(1, span_end - span_start)
     total_weight = sum(_char_width_weight(char) for char in original) or 1.0
-    cursor = float(x_min)
+    cursor = float(span_start)
     runs = []
     current_kind = None
     current_text = []
@@ -228,21 +257,17 @@ def _split_mixed_hangul_runs(text, bbox):
             run_kind = "overlay"
         cleaned = _clean_split_run("".join(current_text), run_kind)
         if cleaned:
-            run_x0 = _clamp_int(current_start)
-            run_x1 = _clamp_int(end_x)
-            if run_x1 - run_x0 < MIN_BOX_SIZE:
-                run_x1 = min(1000, run_x0 + MIN_BOX_SIZE)
             runs.append({
                 "kind": run_kind,
                 "text": cleaned,
-                "bbox": [y_min, run_x0, y_max, run_x1],
+                "bbox": _run_bbox(axis, y_min, x_min, y_max, x_max, current_start, end_x),
             })
         current_text = []
         current_kind = None
         current_start = end_x
 
     for char in original:
-        width = total_width * (_char_width_weight(char) / total_weight)
+        width = total_span * (_char_width_weight(char) / total_weight)
         next_cursor = cursor + width
         kind = char_kind(char)
         if current_kind is None:
@@ -254,7 +279,7 @@ def _split_mixed_hangul_runs(text, bbox):
             current_start = cursor
         current_text.append(char)
         cursor = next_cursor
-    flush(float(x_max))
+    flush(float(span_end))
     return _merge_adjacent_runs(runs)
 
 

--- a/ideogram_prompt_polish_node/prompt_polish.py
+++ b/ideogram_prompt_polish_node/prompt_polish.py
@@ -181,15 +181,46 @@ def _merge_adjacent_runs(runs):
     return merged
 
 
+def _split_axis(text, bbox):
+    y_min, x_min, y_max, x_max = _normalize_bbox(bbox)
+    width = max(1, x_max - x_min)
+    height = max(1, y_max - y_min)
+    if "\n" in str(text or ""):
+        return "y"
+    # Large title blocks commonly stack Latin/product text above Korean copy.
+    # Inline labels such as "First Frame (시작 프레임)" are short, so keep them
+    # split horizontally.
+    if width / height >= 2.1 and height >= 180 and len(str(text or "")) >= 18:
+        return "y"
+    return "x"
+
+
+def _run_bbox(axis, y_min, x_min, y_max, x_max, start, end):
+    if axis == "y":
+        run_y0 = _clamp_int(start)
+        run_y1 = _clamp_int(end)
+        if run_y1 - run_y0 < MIN_BOX_SIZE:
+            run_y1 = min(1000, run_y0 + MIN_BOX_SIZE)
+        return [run_y0, x_min, run_y1, x_max]
+    run_x0 = _clamp_int(start)
+    run_x1 = _clamp_int(end)
+    if run_x1 - run_x0 < MIN_BOX_SIZE:
+        run_x1 = min(1000, run_x0 + MIN_BOX_SIZE)
+    return [y_min, run_x0, y_max, run_x1]
+
+
 def _split_mixed_hangul_runs(text, bbox):
     original = str(text or "").strip()
     if not _has_hangul(original):
         return []
 
     y_min, x_min, y_max, x_max = _normalize_bbox(bbox)
-    total_width = max(1, x_max - x_min)
+    axis = _split_axis(original, bbox)
+    span_start = y_min if axis == "y" else x_min
+    span_end = y_max if axis == "y" else x_max
+    total_span = max(1, span_end - span_start)
     total_weight = sum(_char_width_weight(char) for char in original) or 1.0
-    cursor = float(x_min)
+    cursor = float(span_start)
     runs = []
     current_kind = None
     current_text = []
@@ -215,17 +246,17 @@ def _split_mixed_hangul_runs(text, bbox):
             run_kind = "hangul"
         cleaned = _clean_split_run("".join(current_text), run_kind)
         if cleaned:
-            run_x0 = _clamp_int(current_start)
-            run_x1 = _clamp_int(end_x)
-            if run_x1 - run_x0 < MIN_BOX_SIZE:
-                run_x1 = min(1000, run_x0 + MIN_BOX_SIZE)
-            runs.append({"kind": run_kind, "text": cleaned, "bbox": [y_min, run_x0, y_max, run_x1]})
+            runs.append({
+                "kind": run_kind,
+                "text": cleaned,
+                "bbox": _run_bbox(axis, y_min, x_min, y_max, x_max, current_start, end_x),
+            })
         current_text = []
         current_kind = None
         current_start = end_x
 
     for char in original:
-        width = total_width * (_char_width_weight(char) / total_weight)
+        width = total_span * (_char_width_weight(char) / total_weight)
         next_cursor = cursor + width
         kind = char_kind(char)
         if current_kind is None:
@@ -237,7 +268,7 @@ def _split_mixed_hangul_runs(text, bbox):
             current_start = cursor
         current_text.append(char)
         cursor = next_cursor
-    flush(float(x_max))
+    flush(float(span_end))
     return _merge_adjacent_runs(runs)
 
 

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -500,7 +500,7 @@ function installEditor(node) {
             .toobusy-ideogram .preset-bar select { flex: 1; min-width: 0; }
             .toobusy-ideogram .editor {
                 display: grid;
-                grid-template-columns: minmax(0, 0.62fr) minmax(420px, 1.35fr) minmax(150px, 0.36fr);
+                grid-template-columns: minmax(300px, 0.58fr) minmax(560px, 1.6fr) minmax(190px, 0.42fr);
                 gap: 14px;
                 align-items: start;
             }
@@ -564,8 +564,8 @@ function installEditor(node) {
                 display: flex;
                 flex-direction: column;
                 gap: 3px;
-                max-height: 220px;
-                overflow-y: auto;
+                max-height: none;
+                overflow: visible;
             }
             .toobusy-ideogram .layer-row {
                 display: flex;
@@ -599,8 +599,8 @@ function installEditor(node) {
             .toobusy-ideogram .canvas-frame {
                 width: 100%;
                 aspect-ratio: 1 / 1;
-                max-height: 620px;
-                min-height: 320px;
+                max-height: 680px;
+                min-height: 300px;
                 border: 1px solid #58616d;
                 border-radius: 6px;
                 background: #0e1319;
@@ -1012,6 +1012,7 @@ function installEditor(node) {
 
     function applyResolution() {
         const frame = canvas.parentElement;
+        frame.style.aspectRatio = `${resolution.width} / ${resolution.height}`;
         const frameWidth = frame.clientWidth || 560;
         const frameHeight = frame.clientHeight || 560;
         const scale = Math.min(frameWidth / resolution.width, frameHeight / resolution.height);
@@ -2445,8 +2446,8 @@ function installEditor(node) {
     renderElementPanel();
     applyResolution();
 
-    const PREFERRED_WIDTH = 980;
-    const MIN_WIDTH = 900;
+    const PREFERRED_WIDTH = 1180;
+    const MIN_WIDTH = 1080;
     root.style.overflowY = "visible";
 
     // Height tracks the actual content so the node fits snugly (no empty gap or

--- a/tests/test_ideogram_layout_builder.py
+++ b/tests/test_ideogram_layout_builder.py
@@ -81,6 +81,13 @@ def test_mixed_hangul_runs_keep_digits_with_overlay():
     assert "키프레임" in overlay_text
 
 
+def test_wide_title_split_uses_vertical_stack():
+    runs = _mod._split_mixed_hangul_runs("SCAIL-2 캐릭터 교체 모션 트랜스퍼", [40, 60, 340, 720])
+    assert [run["text"] for run in runs] == ["SCAIL-2", "캐릭터 교체 모션 트랜스퍼"]
+    assert runs[0]["bbox"][0] < runs[1]["bbox"][0]
+    assert runs[0]["bbox"][1] == runs[1]["bbox"][1]
+
+
 _MIXED = json.dumps([
     {"bbox": [100, 100, 900, 220], "text": "LTX2.3 두두등장!", "desc": "title"},
     {"bbox": [100, 235, 360, 285], "text": "LTX2.3", "desc": "model label"},

--- a/tests/test_prompt_polish.py
+++ b/tests/test_prompt_polish.py
@@ -169,6 +169,26 @@ def test_mixed_latin_hangul_text_is_split_before_builder():
     assert elements[2]["bbox"][1] < elements[3]["bbox"][1]
 
 
+def test_wide_title_split_uses_vertical_stack():
+    payload = {
+        "compositional_deconstruction": {
+            "elements": [
+                {
+                    "type": "text",
+                    "bbox": [40, 60, 340, 720],
+                    "desc": "Stacked title",
+                    "text": "SCAIL-2 캐릭터 교체 모션 트랜스퍼",
+                },
+            ]
+        }
+    }
+    out = _mod._split_mixed_text_elements(payload)
+    elements = out["compositional_deconstruction"]["elements"]
+    assert [element["text"] for element in elements] == ["SCAIL-2", "캐릭터 교체 모션 트랜스퍼"]
+    assert elements[0]["bbox"][0] < elements[1]["bbox"][0]
+    assert elements[0]["bbox"][1] == elements[1]["bbox"][1]
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
## Summary
- choose horizontal vs vertical mixed text splitting based on bbox shape
- keep inline mixed labels like `LTX2.3 두두등장!` split left/right
- split wide stacked title blocks like `SCAIL-2 캐릭터 교체 모션 트랜스퍼` top/bottom
- apply the same fallback split behavior in Layout Builder for older/imported JSON
- make Layout Builder canvas frame follow the selected resolution aspect ratio instead of a square frame
- widen the center canvas column/default node width and remove the tiny inner scroll on the layer list

## Tests
- python tests/test_prompt_polish.py
- python tests/test_ideogram_layout_builder.py
- python -m compileall -q ideogram_prompt_polish_node ideogram_layout_builder
- bundled node --check js/ideogram_layout_builder.js

## Release
- no version bump
- no tag
- no Registry publish