### PR TITLE
Fix builder stage and enrich image layout descriptions

### DIFF
--- a/ideogram_prompt_polish_node/prompt_polish.py
+++ b/ideogram_prompt_polish_node/prompt_polish.py
@@ -314,6 +314,34 @@ def _split_mixed_text_elements(payload):
     return payload
 
 
+def _enrich_element_descriptions(payload):
+    comp = payload.get("compositional_deconstruction")
+    elements = comp.get("elements") if isinstance(comp, dict) else None
+    if not isinstance(elements, list):
+        return payload
+
+    figure_words = ("person", "man", "woman", "male", "female", "figure", "character", "anime", "boy", "girl")
+    for element in elements:
+        if not isinstance(element, dict):
+            continue
+        desc = str(element.get("desc", "")).strip()
+        bbox = _normalize_bbox(element.get("bbox"))
+        height = bbox[2] - bbox[0]
+        width = bbox[3] - bbox[1]
+        lower = desc.lower()
+        if element.get("type") == "obj" and any(word in lower for word in figure_words):
+            if height > width * 1.5 and "full" not in lower and "upper" not in lower and "cropped" not in lower:
+                desc = (
+                    f"{desc}. Full-body head-to-toe character inside the frame, "
+                    "standing pose, visible legs and feet, preserve the full figure silhouette"
+                )
+        if element.get("type") == "obj" and "panel" in lower and "showing" in lower and len(desc) < 90:
+            desc = f"{desc}. Include the visible internal layout, small UI cards, icons, arrows, thumbnails, and labels as seen in the reference."
+        if desc:
+            element["desc"] = desc
+    return payload
+
+
 _SCHEMA_LINES = [
     "Return VALID JSON ONLY (no markdown fences, no commentary) with exactly these top-level keys:",
     '- "high_level_description": string',
@@ -333,6 +361,11 @@ def _build_prompt(scene, style_mode, language, preserve_intent, fill_missing, ex
             "Report what is ACTUALLY in the image — its text, objects, and composition.",
             "Read all visible text EXACTLY, keeping its original language (Korean stays Korean) in the \"text\" field; write \"desc\" fields in English.",
             "Use type \"text\" for readable text (include the exact string), type \"obj\" for everything else (people, icons, panels, products, shapes).",
+            "For every text element, describe visible styling in desc: color, weight, outline/glow, roughness, and orientation such as tilted, slanted, skewed, perspective, arched, stacked, or straight.",
+            "If a text block is visually tilted or distorted, mention that in desc; bbox stays axis-aligned, so desc must carry the tilt/perspective cue.",
+            "For every object element, make desc specific: subject type, full-body vs upper-body/cropped view, pose/action, clothing, expression, important colors, panel/frame shape, icons, arrows, UI controls, and whether it is foreground/background.",
+            "For human/character figures, explicitly state full body, head-to-toe, visible feet/hands, standing pose, or cropped/upper-body if that is what the image shows.",
+            "For large panels and diagrams, describe their internal contents and labels, not just 'panel'.",
             "If one visible label mixes Latin/product text and Korean text, split it into separate text elements with separate bboxes (example: \"LTX2.3 두두등장!\" becomes one bbox for \"LTX2.3\" and another bbox for \"두두등장!\").",
             "If a panel has an English label plus Korean text in parentheses, split them too (example: \"First Frame (시작 프레임)\" becomes separate text elements).",
             "Estimate each bbox from the image. Output ONE element per distinct thing — never duplicate or near-identical boxes for the same item.",
@@ -530,6 +563,7 @@ class ToobusyIdeogramPromptPolish:
 
         payload = _ensure_shape(data, scene, fill_missing_fields)
         payload = _split_mixed_text_elements(payload)
+        payload = _enrich_element_descriptions(payload)
         if image is not None:
             # Vision LLMs often leave palettes empty -> murky generations. Backfill
             # from the real image pixels (whole image + per-element regions).

--- a/js/ideogram_layout_builder.js
+++ b/js/ideogram_layout_builder.js
@@ -598,9 +598,8 @@ function installEditor(node) {
             .toobusy-ideogram .layer-btn:disabled { opacity: 0.35; cursor: default; }
             .toobusy-ideogram .canvas-frame {
                 width: 100%;
-                aspect-ratio: 1 / 1;
-                max-height: 680px;
-                min-height: 300px;
+                height: 620px;
+                min-height: 620px;
                 border: 1px solid #58616d;
                 border-radius: 6px;
                 background: #0e1319;
@@ -1013,7 +1012,6 @@ function installEditor(node) {
 
     function applyResolution() {
         const frame = canvas.parentElement;
-        frame.style.aspectRatio = `${resolution.width} / ${resolution.height}`;
         const frameWidth = frame.clientWidth || 560;
         const frameHeight = frame.clientHeight || 560;
         const scale = Math.min(frameWidth / resolution.width, frameHeight / resolution.height);
@@ -1027,7 +1025,6 @@ function installEditor(node) {
         resolutionReadout.textContent = `${resolution.width} x ${resolution.height}`;
         persistResolution();
         draw();
-        requestAnimationFrame(() => fitNodeToContent());
     }
 
     function point(event) {

--- a/tests/test_prompt_polish.py
+++ b/tests/test_prompt_polish.py
@@ -76,6 +76,8 @@ def test_image_mode_prompt():
     assert "Analyze the provided IMAGE" in text
     assert "Korean stays Korean" in text
     assert "LTX2.3 두두등장!" in text
+    assert "full-body vs upper-body" in text
+    assert "visible feet" in text
     assert "never duplicate or near-identical boxes" in text
     assert SCHEMA_MARK in text  # same schema in both modes
 
@@ -187,6 +189,30 @@ def test_wide_title_split_uses_vertical_stack():
     assert [element["text"] for element in elements] == ["SCAIL-2", "캐릭터 교체 모션 트랜스퍼"]
     assert elements[0]["bbox"][0] < elements[1]["bbox"][0]
     assert elements[0]["bbox"][1] == elements[1]["bbox"][1]
+
+
+def test_full_body_figure_desc_is_enriched():
+    payload = {
+        "compositional_deconstruction": {
+            "elements": [
+                {
+                    "type": "obj",
+                    "bbox": [100, 760, 940, 980],
+                    "desc": "Male anime character in a black leather jacket",
+                },
+                {
+                    "type": "obj",
+                    "bbox": [440, 20, 890, 260],
+                    "desc": "Source panel showing video frames",
+                },
+            ]
+        }
+    }
+    out = _mod._enrich_element_descriptions(payload)
+    elements = out["compositional_deconstruction"]["elements"]
+    assert "Full-body head-to-toe" in elements[0]["desc"]
+    assert "visible legs and feet" in elements[0]["desc"]
+    assert "small UI cards" in elements[1]["desc"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep the Layout Builder canvas inside a fixed stage so resolution/aspect changes resize only the canvas, not the whole node
- strengthen Prompt Polish image-analysis instructions for text styling/orientation and detailed object descriptions
- enrich sparse full-body character and panel descriptions after vision JSON parsing

## Notes
Hangul split remains available as an experimental option, but this keeps the import-to-builder workflow useful while the main Korean text plan shifts toward generating first and inpainting text regions.

## Tests
- python tests/test_prompt_polish.py
- python -m compileall -q ideogram_prompt_polish_node
- bundled node --check js/ideogram_layout_builder.js
- git diff --check

## Release
- no version bump
- no tag
- no Registry publish