### PR TITLE
Release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-06-16
+
 ### Added
 - `toobusy Ideogram Layout Builder`에 **`text_overlay_mode` 토글 + `text_json` 출력** 추가 —
   한글 반자동 파이프라인의 완결. 토글 ON이면 `ideogram_json`에서 **텍스트 요소를 빼서**(Ideogram이

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.2.11"
+version = "0.2.12"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
0.2.11 이후 누적분: Image→Layout via Prompt Polish(Gemma 이미지분석 모드)+팔레트 자동추출, Layout Builder ⟳Pull 브리지+text_overlay_mode 분리 토글, Layout Text Overlay 신규 노드, 캔버스 Delete키 수정. (Florence Image→Layout 노드는 미출시 폐기.) pyproject 0.2.11→0.2.12, CHANGELOG 컷.

🤖 Generated with [Claude Code](https://claude.com/claude-code)