### PR TITLE
Release v0.3.1: audio drag-out + wide audio card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-21
+
+### Fixed
+- `toobusy Reference Board` 노드 프리뷰 카드 드래그아웃이 이미지뿐 아니라 오디오/텍스트/LoRA
+  에서도 동작하도록 보강했습니다. 오디오·이미지는 파일/URL로, 텍스트·LoRA는 텍스트로
+  드래그됩니다.
+
+### Changed
+- `toobusy Reference Board` 오버레이 에디터에서 오디오 카드를 더 넓게(가로형) 표시하고 재생
+  막대를 키워, 세로 카드에서 재생바가 너무 작던 문제를 개선했습니다.
+
 ## [0.3.0] - 2026-06-21
 
 레퍼런스 기반 제작 생태계(Reference Board → Prompt Director → Flux2 Klein)를 처음으로 공개합니다.

--- a/js/toobusy_reference_board.js
+++ b/js/toobusy_reference_board.js
@@ -566,6 +566,11 @@ function injectOverlayStyle() {
             outline: 2px dashed #6aa9ff;
             outline-offset: -2px;
         }
+        .toobusy-ref-card.toobusy-ref-card-audio {
+            width: 360px;
+            min-height: 0;
+        }
+        .toobusy-ref-card-audio .toobusy-ref-audio-player { height: 40px; }
         .toobusy-ref-audio-thumb {
             width: 100%;
             height: 120px;
@@ -1167,6 +1172,7 @@ function createCardElement(item, board, area, hint, sync) {
         return buildTextCard(card, item, board, area, hint, sync);
     }
     const isAudio = isAudioItem(item);
+    if (isAudio) card.classList.add("toobusy-ref-card-audio");
     card.innerHTML = `
         <div class="toobusy-ref-thumb-root"></div>
         <div class="toobusy-ref-card-body">
@@ -1590,40 +1596,63 @@ function refreshLauncher(launcher, node, stateText = "Applied") {
 // Make a node-preview card draggable so it can be dropped into other apps
 // (desktop, Photoshop, browser, etc.) — a real mood-board feel. Images drag as
 // a file/URL; text cards drag their text.
+function dragFileName(item, isAudio) {
+    const fromFile = String(item.filename || "").split(/[\\/]/).pop();
+    if (fromFile && /\.\w+$/.test(fromFile)) return fromFile.replace(/[^\w.-]+/g, "_");
+    const base = `${item.name || item.role || (isAudio ? "audio" : "reference")}`.replace(/[^\w.-]+/g, "_");
+    return base + (isAudio ? ".wav" : ".png");
+}
+
+function dragMime(item, isAudio) {
+    if (item.mime && /\//.test(item.mime)) return item.mime;
+    return isAudio ? "audio/wav" : "image/png";
+}
+
+// Drag a node-preview card out to other apps: images and audio drag as a
+// file/URL; text and lora drag their text.
 function makeSlotDraggable(slot, item, isText, isLora) {
     const audio = isAudioItem(item);
-    const img = slot.querySelector("img");
-    if (img && !isText && !isLora && !audio) {
-        img.draggable = true;
-        img.addEventListener("dragstart", (event) => {
-            const url = referenceViewUrl(item);
-            if (!url) return;
-            hideHoverPreview();
-            let abs = url;
-            try {
-                abs = new URL(url, window.location.href).href;
-            } catch {}
-            const fname = `${item.name || item.role || "reference"}`.replace(/[^\w.-]+/g, "_") + ".png";
-            try {
-                event.dataTransfer.setData("text/uri-list", abs);
-                event.dataTransfer.setData("text/plain", abs);
-                // Chromium: enables drag-out to the OS as an image file.
-                event.dataTransfer.setData("DownloadURL", `image/png:${fname}:${abs}`);
-                event.dataTransfer.effectAllowed = "copy";
-            } catch {}
-        });
-        return;
-    }
-    if (isText) {
+    const dragText = (getText) => {
         slot.draggable = true;
         slot.addEventListener("dragstart", (event) => {
             hideHoverPreview();
             try {
-                event.dataTransfer.setData("text/plain", item.text || "");
+                event.dataTransfer.setData("text/plain", getText() || "");
                 event.dataTransfer.effectAllowed = "copy";
             } catch {}
         });
+    };
+    if (isText) {
+        dragText(() => item.text);
+        return;
     }
+    if (isLora) {
+        dragText(() => item.lora_name);
+        return;
+    }
+    // image or audio media → drag the file/URL
+    const url = referenceViewUrl(item);
+    if (!url) return;
+    const img = slot.querySelector("img");
+    const dragEl = img || slot;
+    if (img) img.draggable = true;
+    else slot.draggable = true;
+    dragEl.addEventListener("dragstart", (event) => {
+        hideHoverPreview();
+        let abs = url;
+        try {
+            abs = new URL(url, window.location.href).href;
+        } catch {}
+        const fname = dragFileName(item, audio);
+        const mime = dragMime(item, audio);
+        try {
+            event.dataTransfer.setData("text/uri-list", abs);
+            event.dataTransfer.setData("text/plain", abs);
+            // Chromium: enables drag-out to the OS as a file.
+            event.dataTransfer.setData("DownloadURL", `${mime}:${fname}:${abs}`);
+            event.dataTransfer.effectAllowed = "copy";
+        } catch {}
+    });
 }
 
 // --- Card thumbnail hover preview (large popup) -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.3.0"
+version = "0.3.1"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Fixed
- Reference Board node-preview card **drag-out** now works for **audio / text / LoRA**, not just images (audio & image drag as a file/URL; text & lora drag their text).

## Changed
- Overlay-editor **audio cards** render wider (horizontal) with a larger playback bar — the player was cramped in the vertical card.

JS/CSS-only. reference_board test suite green, JS brace-balance OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)