### PR TITLE
Release v0.3.2: fix Comfy Registry scanner flag

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -3,6 +3,8 @@
 .github/
 .gitignore
 .comfyignore
+.vscode/
+tests/
 __pycache__/
 *.pyc
 *.pyo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-21
+
+### Fixed
+- Comfy Registry 보안 스캐너(YARA)가 `tests/test_prompt_polish.py`의 `__import__("json")`을
+  obfuscation/code-execution으로 오탐해 0.2.14~0.3.1이 flagged 처리되던 문제를 해결했습니다.
+  해당 코드를 일반 `import json`으로 바꾸고, `.comfyignore`에 `tests/`·`.vscode/`를 추가해
+  발행 패키지에서 테스트/개발 파일을 제외합니다. (노드 동작 변경 없음)
+
 ## [0.3.1] - 2026-06-21
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.3.1"
+version = "0.3.2"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_prompt_polish.py
+++ b/tests/test_prompt_polish.py
@@ -10,6 +10,7 @@ Standalone- and pytest-runnable, no ComfyUI runtime (the module is json/re only)
 """
 
 import importlib.util
+import json
 import os
 import sys
 import types
@@ -220,7 +221,7 @@ def test_polish_keeps_mixed_latin_hangul_label_unsplit():
         preserve_intent=True, fill_missing_fields=True, seed=1,
         analysis_mode="balanced", debug_raw=False,
     )
-    elements = __import__("json").loads(out_json)["compositional_deconstruction"]["elements"]
+    elements = json.loads(out_json)["compositional_deconstruction"]["elements"]
     assert len(elements) == 1
     assert elements[0]["text"] == "LTX2.3 두두등장!"
 


### PR DESCRIPTION
## Fixed
Registry YARA scanner flagged 0.2.14–0.3.1 on `tests/test_prompt_polish.py:223` `__import__("json")` (false positive: any-code-execute / obfuscated-code / python_bytecode_manipulation).

- Replaced `__import__("json").loads(...)` → `import json` + `json.loads(...)`.
- Added `tests/` + `.vscode/` to `.comfyignore` so dev/test files no longer ship in the published package (the test file was being scanned).

No node behavior change. Full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)