### PR TITLE
Release v0.3.4: cache Hires Upscale model loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-06-22
+
+### Fixed
+- `toobusy Hires Upscale`도 내부 `UpscaleModelLoader`를 v0.3.3의 공유 캐시(`_load_cached`)로
+  돌려, 반복 실행마다 업스케일 모델을 다시 읽어 VRAM이 피크를 치던 부분을 줄였습니다.
+  (업스케일 연산 자체의 메모리 사용은 4x 업스케일 특성상 별개이며 `scale_by`로 조절합니다.)
+
 ## [0.3.3] - 2026-06-22
 
 ### Fixed

--- a/hires_upscale_node/hires_upscale.py
+++ b/hires_upscale_node/hires_upscale.py
@@ -10,7 +10,7 @@ to the working resolution (4x * 0.5 = a clean 2x with model detail), and the
 result is VAE-encoded so it can feed a second sampler pass directly.
 """
 
-from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _call_node
+from ..ltx23_compact_sampler_node.ltx23_compact_sampler import _call_node, _load_cached
 
 PREFERRED_DEFAULT_MODELS = (
     "ESRGAN/4x_foolhardy_Remacri.pth",
@@ -98,7 +98,7 @@ class ToobusyHiresUpscale:
 
     def upscale(self, image, vae, upscale_model_name, downscale_method, scale_by, upscale_model=None):
         if upscale_model is None:
-            upscale_model = _call_node("UpscaleModelLoader", model_name=upscale_model_name)[0]
+            upscale_model = _load_cached("UpscaleModelLoader", model_name=upscale_model_name)
         else:
             print("[toobusy Hires Upscale] Using connected upscale_model override.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.3.3"
+version = "0.3.4"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_hires_upscale.py
+++ b/tests/test_hires_upscale.py
@@ -42,6 +42,9 @@ def _install_stubs():
 
     samp = types.ModuleType("toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler")
     samp._call_node = fake_call_node
+    # Non-caching passthrough so loader-call assertions stay deterministic.
+    samp._load_cached = lambda class_name, **kwargs: fake_call_node(class_name, **kwargs)[0]
+    samp._clear_loader_cache = lambda: None
     sys.modules["toobusy.ltx23_compact_sampler_node.ltx23_compact_sampler"] = samp
 
 


### PR DESCRIPTION
## Fixed
`toobusy Hires Upscale` loaded `UpscaleModelLoader` internally without caching → it re-read the upscale model on every re-execution (VRAM peak). Routed through the shared `_load_cached` helper added in v0.3.3.

The upscale operation's own VRAM use (4x ESRGAN on a large image + VAEEncode of the big result) is inherent to upscaling and is tuned via `scale_by`, not by caching.

Full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)