### PR TITLE
Improve Ideogram presets, Sage, and CLIP handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ComfyUI를 재시작하세요. 프런트엔드(JS) 변경을 받은 뒤에는 �
 | 기획 | `toobusy Storyboard Board` | ComfyUI 안에서 이미지 보드와 키프레임 마킹을 처리합니다. |
 | 기획 | `toobusy Paint Canvas` | 그래프 앞단에서 러프 페인팅과 마스크를 만들고 바로 생성 노드로 보냅니다. |
 | 텍스트 인코더 | `toobusy Load CLIP` | safetensors/`.gguf` 텍스트 인코더를 한 노드로 로드합니다. |
-| Ideogram | `toobusy Ideogram Prompt Polish` / `Layout Builder` / `Ideogram4 T2I` | 한국어 장면 → 구조화 프롬프트 → 레이아웃 → 로컬 Ideogram4 생성 흐름입니다. Prompt Polish는 `image`+비전 모델(Gemma 4) 연결 시 **이미지 1장을 분석해 레이아웃 JSON 초안**도 만들고, Layout Builder의 `⟳ Pull from input`으로 캔버스에 올립니다. |
+| Ideogram | `toobusy Ideogram Prompt Polish` / `Layout Builder` / `Ideogram4 T2I` | 한국어 장면 → 구조화 프롬프트 → 레이아웃 → 로컬 Ideogram4 생성 흐름입니다. Prompt Polish는 `image`+비전 모델(Gemma 4) 연결 시 **이미지 1장을 분석해 레이아웃 JSON 초안**도 만들고, Layout Builder의 `⟳ Pull from input`으로 캔버스에 올립니다. `release_clip_after_run`은 프롬프트 생성 뒤 해당 CLIP만 VRAM에서 내려 대형 생성 모델과의 병목을 줄입니다. T2I의 공식 품질 프리셋은 권장 sampler/CFG/스케줄 값을 함께 적용하며, KJNodes가 있으면 SageAttention을 노드 안에서 켤 수 있습니다. |
 | Ideogram | `toobusy Layout Text Overlay` | 생성된 이미지 위에 실제 한글 텍스트를 인터랙티브하게(드래그·편집·폰트크기) 얹어, Ideogram이 못 그리는 한글을 크리스피하게 렌더합니다(layout_json 자동 시드). |
 | LTX | `toobusy LTX2.3` 3종 | LTX2.3 AV 프롬프트, 빈 latent, 샘플러 블록을 컴팩트하게 만듭니다. |
 

--- a/ideogram4_t2i_node/ideogram4_t2i.py
+++ b/ideogram4_t2i_node/ideogram4_t2i.py
@@ -166,6 +166,13 @@ class ToobusyIdeogram4T2I:
                 ),
                 "cfg": ("FLOAT", {"default": 7.0, "min": 0.0, "max": 100.0, "step": 0.1}),
                 "lora_slots": ("INT", {"default": 0, "min": 0, "max": MAX_LORA_SLOTS}),
+                "use_sage_attention": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": "Patch only this node's conditional and unconditional Ideogram models with KJ SageAttention auto mode.",
+                    },
+                ),
             },
             "optional": {
                 "model_override": ("MODEL",),
@@ -185,7 +192,7 @@ class ToobusyIdeogram4T2I:
                 "mu": ("FLOAT", {"default": 0.5, "min": -10.0, "max": 10.0, "step": 0.05, "tooltip": "Used only when quality = Custom."}),
                 "std": ("FLOAT", {"default": 1.75, "min": 0.1, "max": 5.0, "step": 0.05, "tooltip": "Used only when quality = Custom."}),
                 "cfg_override": ("FLOAT", {"default": 3.0, "min": 0.0, "max": 100.0, "step": 0.1}),
-                "cfg_override_start": ("FLOAT", {"default": 0.9, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "cfg_override_start": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "cfg_override_end": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
             },
         }
@@ -221,12 +228,13 @@ class ToobusyIdeogram4T2I:
         sampler_name,
         cfg,
         lora_slots,
+        use_sage_attention=False,
         width=0,
         height=0,
         mu=0.5,
         std=1.75,
         cfg_override=3.0,
-        cfg_override_start=0.9,
+        cfg_override_start=0.7,
         cfg_override_end=1.0,
         model_override=None,
         uncond_model_override=None,
@@ -235,14 +243,23 @@ class ToobusyIdeogram4T2I:
         **lora_kwargs,
     ):
         if quality == "Custom":
-            preset_steps = int(steps) if int(steps) > 0 else 20
-            preset_mu, preset_std = float(mu), float(std)
+            steps = int(steps) if int(steps) > 0 else 20
+            mu, std = float(mu), float(std)
+            effective_sampler_name = sampler_name
+            effective_cfg = float(cfg)
+            effective_cfg_override = float(cfg_override)
+            effective_cfg_override_start = float(cfg_override_start)
+            effective_cfg_override_end = float(cfg_override_end)
         else:
-            preset_steps, preset_mu, preset_std = QUALITY_PRESETS.get(quality, QUALITY_PRESETS["Turbo"])
-            if int(steps) > 0:  # manual override of the preset step count
-                preset_steps = int(steps)
-
-        steps, mu, std = preset_steps, preset_mu, preset_std
+            # Official Ideogram presets are atomic. Saved legacy widget values
+            # must not silently turn Turbo/Default/Quality into a hand-tuned
+            # hybrid; use Custom when manual control is intentional.
+            steps, mu, std = QUALITY_PRESETS.get(quality, QUALITY_PRESETS["Turbo"])
+            effective_sampler_name = "euler"
+            effective_cfg = 7.0
+            effective_cfg_override = 3.0
+            effective_cfg_override_start = 0.7
+            effective_cfg_override_end = 1.0
 
         # Resolution: explicit width/height (e.g. from the Layout Builder) wins;
         # otherwise derive from ratio_preset + megapixels.
@@ -304,22 +321,45 @@ class ToobusyIdeogram4T2I:
         model = _call_node(
             "CFGOverride",
             model=model,
-            cfg=float(cfg_override),
-            start_percent=float(cfg_override_start),
-            end_percent=float(cfg_override_end),
+            cfg=effective_cfg_override,
+            start_percent=effective_cfg_override_start,
+            end_percent=effective_cfg_override_end,
         )[0]
+
+        # Insert the KJ model patch at the last model-processing point, after
+        # LoRA and CFG have finished cloning/patching the models and immediately
+        # before both branches enter DualModelGuider.
+        if use_sage_attention:
+            try:
+                model = _call_node(
+                    "PathchSageAttentionKJ",
+                    model=model,
+                    sage_attention="auto",
+                    allow_compile=False,
+                )[0]
+                model_uncond = _call_node(
+                    "PathchSageAttentionKJ",
+                    model=model_uncond,
+                    sage_attention="auto",
+                    allow_compile=False,
+                )[0]
+            except Exception as exc:
+                raise RuntimeError(
+                    "use_sage_attention needs KJNodes plus a working SageAttention installation. "
+                    "Turn the switch off to run without it."
+                ) from exc
 
         guider = _call_node(
             "DualModelGuider",
             model=model,
             positive=positive,
-            cfg=float(cfg),
+            cfg=effective_cfg,
             model_negative=model_uncond,
             negative=negative,
         )[0]
 
         noise = _call_node("RandomNoise", noise_seed=int(seed))[0]
-        sampler = _call_node("KSamplerSelect", sampler_name=sampler_name)[0]
+        sampler = _call_node("KSamplerSelect", sampler_name=effective_sampler_name)[0]
         sigmas = _call_node(
             "Ideogram4Scheduler",
             steps=int(steps),

--- a/ideogram_prompt_polish_node/prompt_polish.py
+++ b/ideogram_prompt_polish_node/prompt_polish.py
@@ -610,6 +610,29 @@ def _enrich_palette(payload, image, element_colors=5, style_colors=8):
     return payload
 
 
+def _release_clip_from_vram(clip):
+    """Unload only this prompt CLIP and its clones, preserving other models.
+
+    This is the narrow hand-off needed by large chained workflows: a vision
+    prompt model (for example Gemma 4) can leave VRAM before Ideogram starts,
+    without the global cache destruction performed by generic VRAM cleaners.
+    """
+    patcher = getattr(clip, "patcher", None)
+    if patcher is None:
+        return False
+    try:
+        from comfy import model_management
+
+        model_management.unload_model_and_clones(patcher)
+        model_management.soft_empty_cache()
+        return True
+    except ImportError:
+        return False
+    except Exception as exc:  # noqa: BLE001 - cleanup must not discard a valid prompt
+        print(f"[toobusy] Could not release prompt CLIP from VRAM: {exc}")
+        return False
+
+
 class ToobusyIdeogramPromptPolish:
     """Folds Korean/English scene writing -> English translation -> Ideogram prompt structuring into one node.
 
@@ -643,6 +666,13 @@ class ToobusyIdeogramPromptPolish:
                 "seed": (
                     "INT",
                     {"default": 1, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True},
+                ),
+                "release_clip_after_run": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "After creating the prompt, unload only this CLIP model from VRAM. Recommended before a large Ideogram model; unlike a global VRAM cleaner, other models and caches are preserved.",
+                    },
                 ),
             },
             "optional": {
@@ -691,6 +721,7 @@ class ToobusyIdeogramPromptPolish:
         preserve_intent,
         fill_missing_fields,
         seed,
+        release_clip_after_run=True,
         existing_layout_json="",
         image=None,
         image_instruction_mode="Analyze image literally",
@@ -727,6 +758,9 @@ class ToobusyIdeogramPromptPolish:
             print(message)
             fallback = _ensure_shape({}, scene, True)
             return (json.dumps(fallback, ensure_ascii=False, indent=2), message)
+        finally:
+            if release_clip_after_run:
+                _release_clip_from_vram(clip)
 
         data = _extract_json(raw)
         if data is None:

--- a/js/toobusy_ideogram4_t2i.js
+++ b/js/toobusy_ideogram4_t2i.js
@@ -1,9 +1,66 @@
 import { app } from "../../scripts/app.js";
 
 const MAX_LORA_SLOTS = 5;
+const QUALITY_PRESETS = {
+    Quality: { steps: 48, mu: 0.0, std: 1.5 },
+    Default: { steps: 20, mu: 0.0, std: 1.75 },
+    Turbo: { steps: 12, mu: 0.5, std: 1.75 },
+};
 
 function findWidget(node, name) {
     return node.widgets?.find((widget) => widget.name === name);
+}
+
+function numericWidgetValue(node, name, fallback) {
+    const value = Number(findWidget(node, name)?.value);
+    return Number.isFinite(value) ? value : fallback;
+}
+
+function resolvedSettingsText(node) {
+    const quality = String(findWidget(node, "quality")?.value ?? "Turbo");
+    const preset = QUALITY_PRESETS[quality];
+    const manualSteps = Math.round(numericWidgetValue(node, "steps", 0));
+    const isCustom = quality === "Custom";
+    const steps = isCustom ? (manualSteps > 0 ? manualSteps : 20) : preset.steps;
+    const mu = quality === "Custom" ? numericWidgetValue(node, "mu", 0.5) : preset.mu;
+    const std = quality === "Custom" ? numericWidgetValue(node, "std", 1.75) : preset.std;
+    const sampler = isCustom ? String(findWidget(node, "sampler_name")?.value ?? "euler") : "euler";
+    const cfg = isCustom ? numericWidgetValue(node, "cfg", 7.0) : 7.0;
+    const tailCfg = isCustom ? numericWidgetValue(node, "cfg_override", 3.0) : 3.0;
+    const tailStart = isCustom ? numericWidgetValue(node, "cfg_override_start", 0.7) : 0.7;
+    const tailEnd = isCustom ? numericWidgetValue(node, "cfg_override_end", 1.0) : 1.0;
+    const sage = Boolean(findWidget(node, "use_sage_attention")?.value);
+    return `${quality}: ${steps} steps  ·  ${sampler}  ·  μ ${mu} / σ ${std}\nCFG ${cfg} → ${tailCfg} @ ${Math.round(tailStart * 100)}–${Math.round(tailEnd * 100)}%  ·  Sage ${sage ? "ON" : "OFF"}`;
+}
+
+function updateResolvedSettings(node) {
+    if (!node._toobusyResolvedSettings) return;
+    node._toobusyResolvedSettings.value = resolvedSettingsText(node);
+    node.setDirtyCanvas?.(true, true);
+}
+
+function watchResolvedSetting(node, name) {
+    const widget = findWidget(node, name);
+    if (!widget || widget._toobusyResolvedWatched) return;
+    widget._toobusyResolvedWatched = true;
+    const callback = widget.callback;
+    widget.callback = function () {
+        const result = callback?.apply(this, arguments);
+        if (name === "quality") updatePresetControls(node);
+        else updateResolvedSettings(node);
+        return result;
+    };
+}
+
+function updatePresetControls(node) {
+    const isCustom = String(findWidget(node, "quality")?.value ?? "Turbo") === "Custom";
+    for (const name of [
+        "steps", "sampler_name", "cfg", "mu", "std",
+        "cfg_override", "cfg_override_start", "cfg_override_end",
+    ]) {
+        setWidgetVisible(node, findWidget(node, name), isCustom);
+    }
+    updateResolvedSettings(node);
 }
 
 function setWidgetVisible(node, widget, visible) {
@@ -106,6 +163,31 @@ app.registerExtension({
         nodeType.prototype.onNodeCreated = function () {
             onNodeCreated?.apply(this, arguments);
 
+            const readout = this.addWidget(
+                "customtext",
+                "Resolved settings",
+                "",
+                () => {},
+                { serialize: false },
+            );
+            readout.inputEl?.setAttribute?.("readonly", "readonly");
+            this._toobusyResolvedSettings = readout;
+
+            // Keep the applied values visible directly below the quality selector.
+            const widgets = this.widgets;
+            const readoutIndex = widgets.indexOf(readout);
+            if (readoutIndex >= 0) widgets.splice(readoutIndex, 1);
+            const qualityWidget = findWidget(this, "quality");
+            const qualityIndex = qualityWidget ? widgets.indexOf(qualityWidget) : -1;
+            widgets.splice(qualityIndex >= 0 ? qualityIndex + 1 : widgets.length, 0, readout);
+
+            for (const name of [
+                "quality", "steps", "mu", "std", "cfg", "cfg_override",
+                "cfg_override_start", "cfg_override_end", "use_sage_attention",
+            ]) {
+                watchResolvedSetting(this, name);
+            }
+
             const slotWidget = findWidget(this, "lora_slots");
             if (slotWidget) {
                 setWidgetVisible(this, slotWidget, false);
@@ -140,12 +222,14 @@ app.registerExtension({
             }, { serialize: false });
 
             updateLoraSlots(this);
+            updatePresetControls(this);
         };
 
         const onConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
             onConfigure?.apply(this, arguments);
             updateLoraSlots(this);
+            updatePresetControls(this);
         };
     },
 });

--- a/tests/test_model_overrides.py
+++ b/tests/test_model_overrides.py
@@ -29,6 +29,7 @@ LOADER_NODES = ("UNETLoader", "CLIPLoader", "VAELoader")
 
 # Shared call log populated by the stubbed _call_node.
 _CALLS = []
+_CALL_DETAILS = []
 _samp = None
 
 
@@ -41,6 +42,7 @@ def _install_stubs():
 
     def fake_call_node(node_type, **kwargs):
         _CALLS.append(node_type)
+        _CALL_DETAILS.append((node_type, kwargs))
         return [f"<{node_type}-out>"]
 
     pkg = types.ModuleType("toobusy")
@@ -100,7 +102,9 @@ def test_zimage_exposes_override_inputs():
 
 
 def test_ideogram4_exposes_override_inputs():
+    required = _ideo.ToobusyIdeogram4T2I.INPUT_TYPES()["required"]
     optional = _ideo.ToobusyIdeogram4T2I.INPUT_TYPES()["optional"]
+    assert required["use_sage_attention"][0] == "BOOLEAN"
     assert optional.get("model_override") == ("MODEL",)
     assert optional.get("uncond_model_override") == ("MODEL",)
     assert optional.get("clip_override") == ("CLIP",)
@@ -122,12 +126,19 @@ def _run_zimage(**overrides):
 
 def _run_ideogram4(**overrides):
     _CALLS.clear()
+    _CALL_DETAILS.clear()
     _samp._clear_loader_cache()
-    _ideo.ToobusyIdeogram4T2I().generate(
+    settings = dict(
         model_name="m", unconditional_model_name="um", clip_name="c", vae_name="v",
         prompt="{}", quality="Turbo", steps=0, ratio_preset="1:1", megapixels=1.0,
-        seed=0, sampler_name="res_multistep", cfg=7.0, lora_slots=0, **overrides,
+        seed=0, sampler_name="res_multistep", cfg=7.0, lora_slots=0,
     )
+    settings.update(overrides)
+    _ideo.ToobusyIdeogram4T2I().generate(**settings)
+
+
+def _call_kwargs(node_type):
+    return [kwargs for called_type, kwargs in _CALL_DETAILS if called_type == node_type]
 
 
 def test_zimage_overrides_skip_internal_loaders():
@@ -166,6 +177,46 @@ def test_ideogram4_partial_override_skips_only_connected():
     assert called.count("UNETLoader") == 1  # only the unconditional UNET loads
     assert called.count("CLIPLoader") == 1
     assert called.count("VAELoader") == 1
+
+
+def test_ideogram4_sage_switch_patches_both_models_only():
+    _run_ideogram4(use_sage_attention=True)
+    assert _CALLS.count("PathchSageAttentionKJ") == 2
+
+
+def test_ideogram4_default_does_not_patch_attention():
+    _run_ideogram4()
+    assert "PathchSageAttentionKJ" not in _CALLS
+
+
+def test_ideogram4_named_presets_force_official_settings():
+    _run_ideogram4(
+        quality="Turbo", steps=99, sampler_name="res_multistep", cfg=1.0,
+        mu=9.0, std=9.0, cfg_override=9.0,
+        cfg_override_start=0.9, cfg_override_end=0.9,
+    )
+    assert _call_kwargs("Ideogram4Scheduler")[0]["steps"] == 12
+    assert _call_kwargs("Ideogram4Scheduler")[0]["mu"] == 0.5
+    assert _call_kwargs("Ideogram4Scheduler")[0]["std"] == 1.75
+    assert _call_kwargs("KSamplerSelect")[0]["sampler_name"] == "euler"
+    assert _call_kwargs("CFGOverride")[0]["cfg"] == 3.0
+    assert _call_kwargs("CFGOverride")[0]["start_percent"] == 0.7
+    assert _call_kwargs("CFGOverride")[0]["end_percent"] == 1.0
+    assert _call_kwargs("DualModelGuider")[0]["cfg"] == 7.0
+
+
+def test_ideogram4_custom_keeps_manual_settings():
+    _run_ideogram4(
+        quality="Custom", steps=23, sampler_name="res_multistep", cfg=5.0,
+        mu=0.25, std=1.25, cfg_override=2.5,
+        cfg_override_start=0.6, cfg_override_end=0.95,
+    )
+    assert _call_kwargs("Ideogram4Scheduler")[0]["steps"] == 23
+    assert _call_kwargs("Ideogram4Scheduler")[0]["mu"] == 0.25
+    assert _call_kwargs("Ideogram4Scheduler")[0]["std"] == 1.25
+    assert _call_kwargs("KSamplerSelect")[0]["sampler_name"] == "res_multistep"
+    assert _call_kwargs("CFGOverride")[0]["start_percent"] == 0.6
+    assert _call_kwargs("DualModelGuider")[0]["cfg"] == 5.0
 
 
 def test_loader_wrapper_does_not_retain_outputs():

--- a/tests/test_prompt_polish.py
+++ b/tests/test_prompt_polish.py
@@ -141,7 +141,10 @@ def test_transform_mode_strips_edit_command_language():
 
 
 def test_image_input_exposed_and_optional():
+    required = _mod.ToobusyIdeogramPromptPolish.INPUT_TYPES()["required"]
     optional = _mod.ToobusyIdeogramPromptPolish.INPUT_TYPES()["optional"]
+    assert required["release_clip_after_run"][0] == "BOOLEAN"
+    assert required["release_clip_after_run"][1]["default"] is True
     assert optional["image"][0] == "IMAGE"
     assert optional["image_instruction_mode"][0] == _mod.IMAGE_INSTRUCTION_MODES
     assert optional["image_instruction_mode"][1]["default"] == "Analyze image literally"
@@ -151,6 +154,31 @@ def test_image_input_exposed_and_optional():
     assert optional["debug_raw"][1]["default"] is False
     # image is optional, not required.
     assert "image" not in _mod.ToobusyIdeogramPromptPolish.INPUT_TYPES()["required"]
+
+
+def test_release_clip_unloads_only_the_supplied_patcher():
+    calls = []
+    previous_comfy = sys.modules.get("comfy")
+    comfy = types.ModuleType("comfy")
+    comfy.model_management = types.SimpleNamespace(
+        unload_model_and_clones=lambda patcher: calls.append(("unload", patcher)),
+        soft_empty_cache=lambda: calls.append(("empty", None)),
+    )
+    sys.modules["comfy"] = comfy
+    try:
+        patcher = object()
+        clip = types.SimpleNamespace(patcher=patcher)
+        _mod.ToobusyIdeogramPromptPolish().polish(
+            clip=clip, scene="hint", style_mode="Literal", language="Auto",
+            preserve_intent=True, fill_missing_fields=True, seed=1,
+            release_clip_after_run=True,
+        )
+        assert calls == [("unload", patcher), ("empty", None)]
+    finally:
+        if previous_comfy is None:
+            sys.modules.pop("comfy", None)
+        else:
+            sys.modules["comfy"] = previous_comfy
 
 
 def test_extract_json_handles_fences_and_prose():


### PR DESCRIPTION
## What changed

- make Ideogram Quality, Default, and Turbo choices apply the complete official sampler, schedule, and CFG preset atomically
- hide manual tuning widgets outside Custom mode and show the resolved settings in the node
- add an internal KJNodes SageAttention switch at the final model-patching point for both conditional and unconditional models
- add `release_clip_after_run` to Ideogram Prompt Polish so only its Gemma/CLIP model and clones leave VRAM after prompt generation
- document the new handoff behavior and add regression coverage

## Why

The generic `easy cleanGpuUsed` handoff unloads every loaded model and destroys broad caches. It did prevent the prompt CLIP from competing with Ideogram on a 24 GB GPU, but it also forced unnecessary cold initialization. The new targeted handoff preserves that VRAM boundary while leaving unrelated models and caches alone.

Saved manual widget values could also silently produce hybrid named presets. Named qualities now stay deterministic; users who want manual control can select Custom.

## User impact

Prompt Polish can safely hand VRAM from Gemma 4 to Ideogram 4 without a global cleaner. Ideogram users get predictable official presets, a visible resolved-settings summary, and an optional in-node SageAttention path.

## Validation

- `python -m pytest tests/test_prompt_polish.py tests/test_model_overrides.py -q`
- 27 tests passed
- `git diff --check`
