### PR TITLE
Release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-07-18
+
+### Added
+- Added an optional in-node SageAttention switch for both Ideogram 4 model
+  branches, applied after LoRA and CFG model patches.
+- Added `release_clip_after_run` to Ideogram Prompt Polish so a large prompt
+  CLIP such as Gemma 4 can leave VRAM without globally unloading every model.
+- Added movable whiteboard artboards, nested layer groups, safer drawing and
+  recovery, and sequential image-list output for all artboards.
+
+### Changed
+- Ideogram 4 Quality, Default, and Turbo now apply the complete official
+  sampler, schedule, and CFG settings. Manual tuning remains available through
+  Custom mode, while a resolved-settings readout shows what will actually run.
+
+### Fixed
+- Avoided the broad cache destruction caused by using a global VRAM cleaner as
+  the hand-off between prompt generation and Ideogram model initialization.
+- Improved whiteboard coordinate handling, resizing, layer ownership, and
+  restoration after frontend state changes.
+
 ## [0.3.7] - 2026-07-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.3.7"
+version = "0.3.8"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What changed

- bump the package version to 0.3.8
- document the Ideogram preset, SageAttention, targeted CLIP handoff, and whiteboard improvements

## Why

The code was merged to `main`, but Comfy Registry publishing is tag-driven. A version bump and release tag are required for users to receive the improvements through normal updates.

## User impact

After the v0.3.8 tag is published, Comfy Registry users can update to the release containing all currently merged improvements.

## Validation

- parsed `pyproject.toml` and verified project version `0.3.8`
- full Python regression suite and frontend syntax checks passed on the release code before this metadata-only bump
- `git diff --check`
