### PR TITLE
Fix Prompt Polish widget compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-07-19
+
+### Fixed
+- Restored positional compatibility for existing Ideogram Prompt Polish
+  workflows. `release_clip_after_run` is now appended after all pre-existing
+  widgets instead of being inserted before the image-analysis controls.
+- Added a frontend migration for workflows saved with the broken v0.3.8 widget
+  order, preventing `balanced` and `debug_raw` values from being validated as
+  the wrong fields.
+
 ## [0.3.8] - 2026-07-18
 
 ### Added

--- a/ideogram_prompt_polish_node/prompt_polish.py
+++ b/ideogram_prompt_polish_node/prompt_polish.py
@@ -667,13 +667,6 @@ class ToobusyIdeogramPromptPolish:
                     "INT",
                     {"default": 1, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True},
                 ),
-                "release_clip_after_run": (
-                    "BOOLEAN",
-                    {
-                        "default": True,
-                        "tooltip": "After creating the prompt, unload only this CLIP model from VRAM. Recommended before a large Ideogram model; unlike a global VRAM cleaner, other models and caches are preserved.",
-                    },
-                ),
             },
             "optional": {
                 "existing_layout_json": ("STRING", {"multiline": True, "default": ""}),
@@ -704,6 +697,16 @@ class ToobusyIdeogramPromptPolish:
                         "tooltip": "Off: return blank/truncated llm_raw to keep workflows lighter. On: return the full raw LLM response for debugging JSON failures.",
                     },
                 ),
+                # Keep new widgets at the end. ComfyUI serializes widget values
+                # positionally, so inserting this among existing fields breaks
+                # saved workflows by shifting image/analysis mode values.
+                "release_clip_after_run": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "After creating the prompt, unload only this CLIP model from VRAM. Recommended before a large Ideogram model; unlike a global VRAM cleaner, other models and caches are preserved.",
+                    },
+                ),
             },
         }
 
@@ -721,12 +724,12 @@ class ToobusyIdeogramPromptPolish:
         preserve_intent,
         fill_missing_fields,
         seed,
-        release_clip_after_run=True,
         existing_layout_json="",
         image=None,
         image_instruction_mode="Analyze image literally",
         analysis_mode="balanced",
         debug_raw=False,
+        release_clip_after_run=True,
     ):
         # Imported lazily so this module stays import-light (json/re only) and
         # unit-testable outside ComfyUI; reuses the same TextGenerate call the

--- a/js/toobusy_ideogram_prompt_polish.js
+++ b/js/toobusy_ideogram_prompt_polish.js
@@ -1,0 +1,55 @@
+import { app } from "../../scripts/app.js";
+
+const IMAGE_MODES = ["Analyze image literally", "Transform by scene text"];
+const ANALYSIS_MODES = ["fast", "balanced", "detailed"];
+
+function widget(node, name) {
+    return node.widgets?.find((item) => item.name === name);
+}
+
+function migrateBrokenV038WidgetOrder(node) {
+    const existing = widget(node, "existing_layout_json");
+    const imageMode = widget(node, "image_instruction_mode");
+    const analysis = widget(node, "analysis_mode");
+    const debugRaw = widget(node, "debug_raw");
+    const releaseClip = widget(node, "release_clip_after_run");
+    if (!existing || !imageMode || !analysis || !debugRaw || !releaseClip) return;
+
+    // v0.3.8 inserted release_clip_after_run before existing widgets. A graph
+    // saved in that version has this positional shape when opened after the
+    // field is moved to the safe final position:
+    // existing <- release, image mode <- existing, analysis <- image mode,
+    // debug <- analysis, release <- debug.
+    const isBrokenV038 = typeof existing.value === "boolean"
+        && IMAGE_MODES.includes(String(analysis.value))
+        && ANALYSIS_MODES.includes(String(debugRaw.value));
+    if (!isBrokenV038) return;
+
+    const oldRelease = existing.value;
+    const oldExisting = imageMode.value;
+    const oldImageMode = analysis.value;
+    const oldAnalysis = debugRaw.value;
+    const oldDebug = releaseClip.value;
+
+    existing.value = typeof oldExisting === "string" ? oldExisting : "";
+    imageMode.value = IMAGE_MODES.includes(String(oldImageMode))
+        ? oldImageMode : IMAGE_MODES[0];
+    analysis.value = ANALYSIS_MODES.includes(String(oldAnalysis))
+        ? oldAnalysis : "balanced";
+    debugRaw.value = typeof oldDebug === "boolean" ? oldDebug : false;
+    releaseClip.value = typeof oldRelease === "boolean" ? oldRelease : true;
+    console.warn("[toobusy] Repaired Ideogram Prompt Polish widget order saved by v0.3.8.");
+}
+
+app.registerExtension({
+    name: "toobusy.ideogramPromptPolishCompatibility",
+    async beforeRegisterNodeDef(nodeType, nodeData) {
+        if (nodeData.name !== "ToobusyIdeogramPromptPolish") return;
+        const original = nodeType.prototype.onConfigure;
+        nodeType.prototype.onConfigure = function () {
+            const result = original?.apply(this, arguments);
+            migrateBrokenV038WidgetOrder(this);
+            return result;
+        };
+    },
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.3.8"
+version = "0.3.9"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_prompt_polish.py
+++ b/tests/test_prompt_polish.py
@@ -143,8 +143,12 @@ def test_transform_mode_strips_edit_command_language():
 def test_image_input_exposed_and_optional():
     required = _mod.ToobusyIdeogramPromptPolish.INPUT_TYPES()["required"]
     optional = _mod.ToobusyIdeogramPromptPolish.INPUT_TYPES()["optional"]
-    assert required["release_clip_after_run"][0] == "BOOLEAN"
-    assert required["release_clip_after_run"][1]["default"] is True
+    assert "release_clip_after_run" not in required
+    assert optional["release_clip_after_run"][0] == "BOOLEAN"
+    assert optional["release_clip_after_run"][1]["default"] is True
+    assert list(optional)[-4:] == [
+        "image_instruction_mode", "analysis_mode", "debug_raw", "release_clip_after_run"
+    ]
     assert optional["image"][0] == "IMAGE"
     assert optional["image_instruction_mode"][0] == _mod.IMAGE_INSTRUCTION_MODES
     assert optional["image_instruction_mode"][1]["default"] == "Analyze image literally"


### PR DESCRIPTION
## What changed

- move `release_clip_after_run` to the end of the existing Prompt Polish widget schema
- add a frontend migration for graphs saved with the broken v0.3.8 positional order
- add a regression assertion that future Prompt Polish widgets remain append-only
- bump the package to v0.3.9

## Root cause

ComfyUI serializes widget values positionally. v0.3.8 inserted the new release switch before existing image-analysis widgets, so older workflows queued `balanced` as `image_instruction_mode` and `False` as `analysis_mode`, failing prompt validation.

## User impact

Workflows created before v0.3.8 keep their original values, and workflows saved during v0.3.8 are repaired when configured in the frontend. The targeted CLIP unload remains enabled by default.

## Validation

- 15 Prompt Polish regression tests passed
- Python byte-compile passed
- all frontend modules passed esbuild syntax validation
- package metadata parsed as v0.3.9
- `git diff --check`
