### PR TITLE
Add FlashVSR decode presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,23 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
-## [Unreleased]
+## [0.4.1] - 2026-08-07
 
 ### Added
 - Added `toobusy FlashVSR Loader`, `Long Sampler`, and `Full Decoder` for the
   FlashVSR v1.1 Full + Block-Sparse Attention path.
 - Added long-video chunking with overlap blending and a 24GB VRAM reference
   preset (`2x`, 1024x576, 21-frame chunks, 8-frame overlap).
+- Added `safe`, `balanced`, and `fast` VAE decode tile presets.
 
 ### Changed
 - FlashVSR loads the DiT and VAE in separate phases and releases each phase
   before loading the next one. Large GPU models are not retained globally
   between queue runs.
+
+### Fixed
+- Stopped the decoder from mutating cached sampler latents, allowing users to
+  compare decode presets without rerunning or corrupting the sampler output.
 
 ## [0.3.9] - 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python -m pip install -r custom_nodes/toobusy/requirements_flashvsr.txt
 
 그 다음 **현재 Python/PyTorch/CUDA 조합과 정확히 맞는** `block_sparse_attn` wheel을 설치해야 합니다. 위 검증 환경 전용 wheel은 [여기](https://huggingface.co/Wildminder/AI-windows-whl/resolve/main/block_sparse_attn/block_sparse_attn-0.0.2.post2%2Bd20260117.cu130torch2.12.1cxx11abiTRUE-cp313-cp313-win_amd64.whl?download=true)입니다. 다른 환경에는 이 wheel을 설치하면 안 됩니다. ComfyUI Desktop의 Torch 선택을 먼저 끝낸 뒤 BSA를 설치하세요.
 
-24GB 미만 VRAM은 아직 검증하지 않았습니다. `offload=true`가 더 낮은 VRAM 경로지만 속도가 크게 느려질 수 있습니다. 예제는 [`flashvsr_v11_full_bsa_long.json`](docs/workflows/flashvsr_v11_full_bsa_long.json)입니다.
+디코더의 `tile_preset`은 `safe`, `balanced`, `fast`를 제공합니다. 큰 프리셋일수록 VRAM을 더 사용하는 대신 중복 타일 계산을 줄입니다. 24GB 미만 VRAM은 아직 검증하지 않았습니다. `offload=true`가 더 낮은 VRAM 경로지만 속도가 크게 느려질 수 있습니다. 예제는 [`flashvsr_v11_full_bsa_long.json`](docs/workflows/flashvsr_v11_full_bsa_long.json)입니다.
 
 처음 설치했다면 예제 워크플로우부터 여는 것이 가장 빠릅니다.
 

--- a/docs/workflows/flashvsr_v11_full_bsa_long.json
+++ b/docs/workflows/flashvsr_v11_full_bsa_long.json
@@ -81,7 +81,7 @@
       ],
       "outputs": [{"name": "images", "type": "IMAGE", "links": [5]}],
       "properties": {"Node name for S&R": "ToobusyFlashVSRDecoder"},
-      "widgets_values": ["Wan2.1_VAE.pth", true, true]
+      "widgets_values": ["Wan2.1_VAE.pth", true, true, "balanced"]
     },
     {
       "id": 6,

--- a/flashvsr_node/backend/runtime.py
+++ b/flashvsr_node/backend/runtime.py
@@ -144,15 +144,23 @@ def _map_to_image(video):
     return video.add(1.0).div(2.0).clamp_(0.0, 1.0)
 
 
-def decode_chunk(pipe, item, tiled, color_fix):
+DECODE_TILE_PRESETS = {
+    "safe": ((60, 104), (30, 52)),
+    "balanced": ((96, 160), (64, 112)),
+    "fast": ((120, 208), (88, 152)),
+}
+
+
+def decode_chunk(pipe, item, tiled, color_fix, tile_preset="safe"):
     samples = item["samples"]
     pipe.vae.clear_cache()
+    tile_size, tile_stride = DECODE_TILE_PRESETS[tile_preset]
     decoded = pipe.vae.decode(
         samples,
         device="cuda",
         tiled=bool(tiled),
-        tile_size=(60, 104),
-        tile_stride=(30, 52),
+        tile_size=tile_size,
+        tile_stride=tile_stride,
     )
     decoded = _map_to_image(decoded.cpu().float())
     if item["pad_frames"]:

--- a/flashvsr_node/nodes.py
+++ b/flashvsr_node/nodes.py
@@ -111,6 +111,7 @@ class ToobusyFlashVSRDecoder:
                 "vae": (folder_paths.get_filename_list("vae"),),
                 "tiled": ("BOOLEAN", {"default": True}),
                 "color_fix": ("BOOLEAN", {"default": True}),
+                "tile_preset": (["safe", "balanced", "fast"], {"default": "safe"}),
             }
         }
 
@@ -119,7 +120,7 @@ class ToobusyFlashVSRDecoder:
     FUNCTION = "decode"
     CATEGORY = "toobusy/video/FlashVSR"
 
-    def decode(self, flashvsr_latent, vae, tiled, color_fix):
+    def decode(self, flashvsr_latent, vae, tiled, color_fix, tile_preset="safe"):
         vae_path = folder_paths.get_full_path("vae", vae)
         validate_paths(vae_path)
         chunks = flashvsr_latent["chunks"]
@@ -130,9 +131,8 @@ class ToobusyFlashVSRDecoder:
         try:
             pipe, manager = load_vae_pipeline(vae_path)
             for index, item in enumerate(chunks):
-                decoded = decode_chunk(pipe, item, tiled, color_fix)
+                decoded = decode_chunk(pipe, item, tiled, color_fix, tile_preset)
                 images = decoded if images is None else merge_chunk(images, decoded, overlaps[index])
-                chunks[index] = None
                 progress.update(1)
         finally:
             release_pipeline(pipe, manager)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.0"
+version = "0.4.1"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Adds Safe, Balanced, and Fast VAE decode tile presets and prevents cached sampler chunks from being mutated during decode.\n\nTested: Python compile, workflow JSON parse, repository test scripts (15 pass; 3 unrelated Windows CP949 print failures).