### PR TITLE
Add FlashVSR VRAM presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m compileall -q \
             __init__.py \
+            flashvsr_node \
             hires_upscale_node \
             load_clip_node \
             ideogram4_t2i_node \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [0.4.2] - 2026-08-07
+
+### Added
+- Added a VRAM and resolution preset node for 12GB, 16GB, and 24GB+ GPUs.
+- Added aggressive sampler offload for 12GB-class GPUs.
+
+### Changed
+- Fast decode now uses two orientation-aware strips when the latent size fits
+  the verified tile budget.
+- Offloaded DiT blocks now release the previous block before loading the next.
+- Long Sampler now exposes 21 frames as its minimum supported chunk size.
+
 ## [0.4.1] - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ ComfyUI를 재시작하세요. 프런트엔드(JS) 변경을 받은 뒤에는 �
 
 ### FlashVSR v1.1 Full + BSA
 
-긴 영상을 청크 단위로 처리하면서 모델을 단계별로 내리는 3개 노드를 제공합니다.
+긴 영상을 청크 단위로 처리하면서 모델을 단계별로 내리는 노드와 VRAM/해상도 프리셋을 제공합니다.
 
 ```text
 Get Video Components
+-> toobusy FlashVSR VRAM & Resolution Preset
 -> toobusy FlashVSR Loader
 -> toobusy FlashVSR Long Sampler
 -> toobusy FlashVSR Full Decoder
@@ -37,6 +38,8 @@ Get Video Components
 
 - 검증 프리셋: `2x`, `1024x576`, `chunk_frames=21`, `chunk_overlap=8`, Full VAE tiled, BSA.
 - 검증 환경: Windows, RTX 3090 24GB, Python 3.13, PyTorch 2.12.1+cu130.
+- VRAM 프리셋: 12GB는 aggressive offload + Safe decode, 16GB는 standard offload + Balanced decode, 24GB+는 GPU resident + orientation-aware Fast decode를 사용합니다.
+- 해상도 프리셋은 최종 출력 크기를 표시하며 샘플러에는 2배 업스케일 전 기준 크기를 전달합니다.
 - 샘플러가 DiT만 로드한 뒤 CPU latent를 만들고 해제하며, 디코더가 그 다음 VAE만 로드합니다. 실행 사이에 GPU 모델을 전역 캐시하지 않습니다.
 - 모델 자동 다운로드는 하지 않습니다. 아래 파일을 직접 배치해야 합니다.
 
@@ -55,7 +58,7 @@ python -m pip install -r custom_nodes/toobusy/requirements_flashvsr.txt
 
 그 다음 **현재 Python/PyTorch/CUDA 조합과 정확히 맞는** `block_sparse_attn` wheel을 설치해야 합니다. 위 검증 환경 전용 wheel은 [여기](https://huggingface.co/Wildminder/AI-windows-whl/resolve/main/block_sparse_attn/block_sparse_attn-0.0.2.post2%2Bd20260117.cu130torch2.12.1cxx11abiTRUE-cp313-cp313-win_amd64.whl?download=true)입니다. 다른 환경에는 이 wheel을 설치하면 안 됩니다. ComfyUI Desktop의 Torch 선택을 먼저 끝낸 뒤 BSA를 설치하세요.
 
-디코더의 `tile_preset`은 `safe`, `balanced`, `fast`를 제공합니다. 큰 프리셋일수록 VRAM을 더 사용하는 대신 중복 타일 계산을 줄입니다. 24GB 미만 VRAM은 아직 검증하지 않았습니다. `offload=true`가 더 낮은 VRAM 경로지만 속도가 크게 느려질 수 있습니다. 예제는 [`flashvsr_v11_full_bsa_long.json`](docs/workflows/flashvsr_v11_full_bsa_long.json)입니다.
+디코더의 `tile_preset`은 `safe`, `balanced`, `fast`를 제공합니다. 큰 프리셋일수록 VRAM을 더 사용하는 대신 중복 타일 계산을 줄입니다. 12GB Safe는 0.8MP 약 5초 입력을 FHD로 처리하는 실측에서 596.23초, 피크 8.69GB로 완주했습니다. `offload=true` 경로는 VRAM을 크게 낮추지만 속도는 느려질 수 있습니다. 예제는 [`flashvsr_v11_full_bsa_long.json`](docs/workflows/flashvsr_v11_full_bsa_long.json)입니다.
 
 처음 설치했다면 예제 워크플로우부터 여는 것이 가장 빠릅니다.
 

--- a/docs/workflows/flashvsr_v11_full_bsa_long.json
+++ b/docs/workflows/flashvsr_v11_full_bsa_long.json
@@ -1,123 +1,376 @@
 {
   "id": "toobusy-flashvsr-v11-full-bsa-long",
   "revision": 0,
-  "last_node_id": 10,
-  "last_link_id": 8,
+  "last_node_id": 11,
+  "last_link_id": 16,
   "nodes": [
     {
       "id": 1,
       "type": "LoadVideo",
-      "pos": [40, 320],
-      "size": [360, 520],
+      "pos": [
+        40,
+        320
+      ],
+      "size": [
+        360,
+        520
+      ],
       "flags": {},
       "order": 0,
       "mode": 0,
       "inputs": [],
-      "outputs": [{"name": "VIDEO", "type": "VIDEO", "links": [1]}],
-      "properties": {"Node name for S&R": "LoadVideo"},
-      "widgets_values": ["flashcmp_src_mic_face_06mp.mp4", "image"]
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            1
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": [
+        "flashcmp_src_mic_face_06mp.mp4",
+        "image"
+      ]
     },
     {
       "id": 2,
       "type": "GetVideoComponents",
-      "pos": [450, 430],
-      "size": [210, 110],
+      "pos": [
+        450,
+        430
+      ],
+      "size": [
+        210,
+        110
+      ],
       "flags": {},
       "order": 1,
       "mode": 0,
-      "inputs": [{"name": "video", "type": "VIDEO", "link": 1}],
-      "outputs": [
-        {"name": "images", "type": "IMAGE", "links": [2]},
-        {"name": "audio", "type": "AUDIO", "links": [7]},
-        {"name": "fps", "type": "FLOAT", "links": [6]}
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1
+        }
       ],
-      "properties": {"Node name for S&R": "GetVideoComponents"},
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            2
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": [
+            7
+          ]
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "links": [
+            6
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetVideoComponents"
+      },
       "widgets_values": []
     },
     {
       "id": 3,
       "type": "ToobusyFlashVSRLoader",
-      "pos": [710, 80],
-      "size": [440, 170],
+      "pos": [
+        710,
+        80
+      ],
+      "size": [
+        440,
+        170
+      ],
       "flags": {},
       "order": 2,
       "mode": 0,
-      "inputs": [],
-      "outputs": [{"name": "flashvsr_model", "type": "TOOBUSY_FLASHVSR_MODEL", "links": [3]}],
-      "properties": {"Node name for S&R": "ToobusyFlashVSRLoader"},
+      "inputs": [
+        {
+          "name": "offload",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "offload"
+          },
+          "link": 14
+        },
+        {
+          "name": "aggressive_offload",
+          "shape": 7,
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "aggressive_offload"
+          },
+          "link": 15
+        }
+      ],
+      "outputs": [
+        {
+          "name": "flashvsr_model",
+          "type": "TOOBUSY_FLASHVSR_MODEL",
+          "links": [
+            3
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ToobusyFlashVSRLoader"
+      },
       "widgets_values": [
         "diffusion_pytorch_model_streaming_dmd.safetensors",
         "LQ_proj_in.ckpt",
         "posi_prompt.pth",
+        false,
         false
       ]
     },
     {
       "id": 4,
       "type": "ToobusyFlashVSRSampler",
-      "pos": [710, 330],
-      "size": [390, 430],
+      "pos": [
+        710,
+        330
+      ],
+      "size": [
+        390,
+        430
+      ],
       "flags": {},
       "order": 3,
       "mode": 0,
       "inputs": [
-        {"name": "flashvsr_model", "type": "TOOBUSY_FLASHVSR_MODEL", "link": 3},
-        {"name": "images", "type": "IMAGE", "link": 2}
+        {
+          "name": "flashvsr_model",
+          "type": "TOOBUSY_FLASHVSR_MODEL",
+          "link": 3
+        },
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 2
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 9
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 10
+        },
+        {
+          "name": "scale",
+          "type": "INT",
+          "widget": {
+            "name": "scale"
+          },
+          "link": 11
+        },
+        {
+          "name": "chunk_frames",
+          "type": "INT",
+          "widget": {
+            "name": "chunk_frames"
+          },
+          "link": 12
+        },
+        {
+          "name": "chunk_overlap",
+          "type": "INT",
+          "widget": {
+            "name": "chunk_overlap"
+          },
+          "link": 13
+        }
       ],
-      "outputs": [{"name": "flashvsr_latent", "type": "TOOBUSY_FLASHVSR_LATENT", "links": [4]}],
-      "properties": {"Node name for S&R": "ToobusyFlashVSRSampler"},
-      "widgets_values": [1024, 576, 2, 0, "fixed", 21, 8, 11, 3.0, 2.0, 1]
+      "outputs": [
+        {
+          "name": "flashvsr_latent",
+          "type": "TOOBUSY_FLASHVSR_LATENT",
+          "links": [
+            4
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ToobusyFlashVSRSampler"
+      },
+      "widgets_values": [
+        1024,
+        576,
+        2,
+        0,
+        "fixed",
+        21,
+        8,
+        11,
+        3.0,
+        2.0,
+        1
+      ]
     },
     {
       "id": 5,
       "type": "ToobusyFlashVSRDecoder",
-      "pos": [1190, 350],
-      "size": [390, 190],
+      "pos": [
+        1190,
+        350
+      ],
+      "size": [
+        390,
+        190
+      ],
       "flags": {},
       "order": 4,
       "mode": 0,
       "inputs": [
-        {"name": "flashvsr_latent", "type": "TOOBUSY_FLASHVSR_LATENT", "link": 4}
+        {
+          "name": "flashvsr_latent",
+          "type": "TOOBUSY_FLASHVSR_LATENT",
+          "link": 4
+        },
+        {
+          "name": "tile_preset",
+          "type": "STRING",
+          "widget": {
+            "name": "tile_preset"
+          },
+          "link": 16
+        }
       ],
-      "outputs": [{"name": "images", "type": "IMAGE", "links": [5]}],
-      "properties": {"Node name for S&R": "ToobusyFlashVSRDecoder"},
-      "widgets_values": ["Wan2.1_VAE.pth", true, true, "balanced"]
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            5
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ToobusyFlashVSRDecoder"
+      },
+      "widgets_values": [
+        "Wan2.1_VAE.pth",
+        true,
+        true,
+        "fast"
+      ]
     },
     {
       "id": 6,
       "type": "CreateVideo",
-      "pos": [1650, 350],
-      "size": [300, 130],
+      "pos": [
+        1650,
+        350
+      ],
+      "size": [
+        300,
+        130
+      ],
       "flags": {},
       "order": 5,
       "mode": 0,
       "inputs": [
-        {"name": "images", "type": "IMAGE", "link": 5},
-        {"name": "audio", "shape": 7, "type": "AUDIO", "link": 7},
-        {"name": "fps", "type": "FLOAT", "widget": {"name": "fps"}, "link": 6}
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 5
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": 7
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "widget": {
+            "name": "fps"
+          },
+          "link": 6
+        }
       ],
-      "outputs": [{"name": "VIDEO", "type": "VIDEO", "links": [8]}],
-      "properties": {"Node name for S&R": "CreateVideo"},
-      "widgets_values": [24]
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            8
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CreateVideo"
+      },
+      "widgets_values": [
+        24
+      ]
     },
     {
       "id": 7,
       "type": "SaveVideo",
-      "pos": [2020, 230],
-      "size": [520, 620],
+      "pos": [
+        2020,
+        230
+      ],
+      "size": [
+        520,
+        620
+      ],
       "flags": {},
       "order": 6,
       "mode": 0,
-      "inputs": [{"name": "video", "type": "VIDEO", "link": 8}],
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 8
+        }
+      ],
       "outputs": [],
-      "properties": {"Node name for S&R": "SaveVideo"},
-      "widgets_values": ["video/FlashVSR_Compare/toobusy_flashvsr_v11_full_bsa", "mp4", "h264"]
+      "properties": {
+        "Node name for S&R": "SaveVideo"
+      },
+      "widgets_values": [
+        "video/FlashVSR_Compare/toobusy_flashvsr_v11_full_bsa",
+        "mp4",
+        "h264"
+      ]
     },
     {
       "id": 8,
       "type": "MarkdownNote",
-      "pos": [40, -520],
-      "size": [500, 520],
+      "pos": [
+        40,
+        -520
+      ],
+      "size": [
+        500,
+        520
+      ],
       "flags": {},
       "order": 7,
       "mode": 0,
@@ -125,27 +378,43 @@
       "outputs": [],
       "title": "01 · 설치와 모델 위치",
       "properties": {},
-      "widgets_values": ["## FlashVSR v1.1 Full + BSA 설치\n\n### 1. 커스텀 노드\n- https://github.com/nicekriss/toobusy\n\n### 2. 일반 의존성\n```bash\npython -m pip install -r custom_nodes/toobusy/requirements_flashvsr.txt\n```\n\n### 3. Block-Sparse Attention\n현재 **Python / PyTorch / CUDA와 정확히 일치하는 wheel**이 필요합니다.\n\n이번 검증 환경:\n- Python 3.13\n- PyTorch 2.12.1+cu130\n- CUDA 13.0\n- RTX 3090 24GB\n\n### 4. 모델 위치\n`models/FlashVSR/`\n- diffusion_pytorch_model_streaming_dmd.safetensors\n- LQ_proj_in.ckpt\n- posi_prompt.pth\n\n`models/vae/`\n- Wan2.1_VAE.pth"]
+      "widgets_values": [
+        "## FlashVSR v1.1 Full + BSA 설치\n\n### 1. 커스텀 노드\n- https://github.com/nicekriss/toobusy\n\n### 2. 일반 의존성\n```bash\npython -m pip install -r custom_nodes/toobusy/requirements_flashvsr.txt\n```\n\n### 3. Block-Sparse Attention\n현재 **Python / PyTorch / CUDA와 정확히 일치하는 wheel**이 필요합니다.\n\n이번 검증 환경:\n- Python 3.13\n- PyTorch 2.12.1+cu130\n- CUDA 13.0\n- RTX 3090 24GB\n\n### 4. 모델 위치\n`models/FlashVSR/`\n- diffusion_pytorch_model_streaming_dmd.safetensors\n- LQ_proj_in.ckpt\n- posi_prompt.pth\n\n`models/vae/`\n- Wan2.1_VAE.pth"
+      ]
     },
     {
       "id": 9,
       "type": "MarkdownNote",
-      "pos": [570, -520],
-      "size": [500, 520],
+      "pos": [
+        570,
+        -520
+      ],
+      "size": [
+        500,
+        520
+      ],
       "flags": {},
       "order": 8,
       "mode": 0,
       "inputs": [],
       "outputs": [],
-      "title": "02 · RTX 3090 권장값",
+      "title": "02 · VRAM과 해상도 선택",
       "properties": {},
-      "widgets_values": ["## 촬영용 최종 권장 설정\n\n- 입력 리사이즈: **1024 × 576**\n- 업스케일: **2×**\n- Chunk Frames: **21**\n- Chunk Overlap: **8**\n- Local Range: **11**\n- KV Ratio: **3.0**\n- Sparse Ratio: **2.0**\n- Steps: **1**\n- Decoder: **tiled = true**\n- Color Fix: **true**\n- Loader offload: **false** (24GB 기준)\n\n124프레임 검증 결과:\n- 출력: 2048 × 1152 / 24fps\n- 처리 시간: 약 500초\n- 전체 최고 VRAM: 19,661MiB\n- 종료 후: 1,696MiB\n\n⚠️ 다른 AI 모델이 VRAM을 잡고 있으면 먼저 언로드하세요. 이번 97% 점유 원인은 LM Studio에 남아 있던 EXAONE 5.25GB였습니다."]
+      "widgets_values": [
+        "## VRAM & Resolution Preset 사용법\n\n### VRAM Profile\n- **12GB safe**: Aggressive Offload + Safe Decoder\n- **16GB balanced**: Standard Offload + Balanced Decoder\n- **24GB+ fast**: GPU 상주 + 방향 인식 2-strip Fast Decoder\n\n### Output Resolution\n원하는 최종 출력 크기를 고릅니다. 예를 들어 `2048x1152 landscape`를 선택하면 내부에서 1024x576으로 맞춘 뒤 2배로 복원합니다.\n\n공통 권장값은 Chunk 21 / Overlap 8 / Local Range 11 / KV 3.0 / Sparse 2.0 / 1-step입니다.\n\nRTX 3090 실측:\n- 24GB+ Fast: 전체 323.65초 / Decoder 193.83초 / Peak 약 21.2GB\n- 12GB Safe: 전체 596.23초 / Peak 8.69GB\n\n12GB 프로필은 느리지만 0.8MP 약 5초 입력을 FHD로 정상 완주했습니다."
+      ]
     },
     {
       "id": 10,
       "type": "MarkdownNote",
-      "pos": [1100, -520],
-      "size": [500, 520],
+      "pos": [
+        1100,
+        -520
+      ],
+      "size": [
+        500,
+        520
+      ],
       "flags": {},
       "order": 9,
       "mode": 0,
@@ -153,23 +422,232 @@
       "outputs": [],
       "title": "03 · 노드가 VRAM을 쓰는 방식",
       "properties": {},
-      "widgets_values": ["## 왜 3개 노드로 나눴나?\n\n### Loader\n모델을 즉시 GPU에 올리지 않고 **파일 경로만 전달**합니다.\n\n### Long Sampler\nDiT만 로드해 21프레임 청크를 처리하고 결과 latent를 CPU로 내립니다. 샘플링이 끝나면 DiT를 해제합니다.\n\n### Full Decoder\n그 다음 VAE만 로드하고 청크를 순서대로 디코드합니다. 8프레임 오버랩은 크로스페이드로 병합합니다.\n\n따라서 DiT와 VAE를 동시에 GPU에 상주시킬 필요가 없고, 실행 사이에 대형 모델을 전역 캐시하지 않습니다.\n\n### 촬영 순서\n1. 설치·모델 위치 설명\n2. Loader의 BSA / offload 설명\n3. Sampler의 21 / 8 설정 설명\n4. Decoder tiled / color fix 설명\n5. Queue 실행 후 VRAM과 결과 비교"]
+      "widgets_values": [
+        "## 노드 동작 방식\n\n### Preset\nVRAM 프로필과 출력 해상도를 고르면 Loader, Sampler, Decoder 설정이 함께 바뀝니다.\n\n### Loader\n낮은 VRAM에서는 모델을 단계별로 CPU에 내립니다. Aggressive 모드는 LQ residual과 KV cache도 CPU에 보관합니다.\n\n### Long Sampler\nDiT는 영상을 21프레임 청크로 나눠 처리하고 겹치는 구간을 블렌딩합니다.\n\n### Full Decoder\nVAE는 타일로 나눠 디코딩합니다. Fast는 영상 방향에 맞춘 두 개의 strip으로 중복 계산을 줄입니다.\n\n### 촬영 순서\n1. 배포 ZIP 설치\n2. VRAM Profile 12 / 16 / 24GB 선택\n3. Output Resolution 선택\n4. 24GB Fast 실측과 VRAM 확인\n5. 결과 영상 비교"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "ToobusyFlashVSRSettings",
+      "pos": [
+        350,
+        70
+      ],
+      "size": [
+        300,
+        110
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            9
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            10
+          ]
+        },
+        {
+          "name": "scale",
+          "type": "INT",
+          "links": [
+            11
+          ]
+        },
+        {
+          "name": "chunk_frames",
+          "type": "INT",
+          "links": [
+            12
+          ]
+        },
+        {
+          "name": "chunk_overlap",
+          "type": "INT",
+          "links": [
+            13
+          ]
+        },
+        {
+          "name": "offload",
+          "type": "BOOLEAN",
+          "links": [
+            14
+          ]
+        },
+        {
+          "name": "aggressive_offload",
+          "type": "BOOLEAN",
+          "links": [
+            15
+          ]
+        },
+        {
+          "name": "tile_preset",
+          "type": "STRING",
+          "links": [
+            16
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ToobusyFlashVSRSettings"
+      },
+      "widgets_values": [
+        "24GB+ fast",
+        "2048x1152 landscape"
+      ]
     }
   ],
   "links": [
-    [1, 1, 0, 2, 0, "VIDEO"],
-    [2, 2, 0, 4, 1, "IMAGE"],
-    [3, 3, 0, 4, 0, "TOOBUSY_FLASHVSR_MODEL"],
-    [4, 4, 0, 5, 0, "TOOBUSY_FLASHVSR_LATENT"],
-    [5, 5, 0, 6, 0, "IMAGE"],
-    [6, 2, 2, 6, 2, "FLOAT"],
-    [7, 2, 1, 6, 1, "AUDIO"],
-    [8, 6, 0, 7, 0, "VIDEO"]
+    [
+      1,
+      1,
+      0,
+      2,
+      0,
+      "VIDEO"
+    ],
+    [
+      2,
+      2,
+      0,
+      4,
+      1,
+      "IMAGE"
+    ],
+    [
+      3,
+      3,
+      0,
+      4,
+      0,
+      "TOOBUSY_FLASHVSR_MODEL"
+    ],
+    [
+      4,
+      4,
+      0,
+      5,
+      0,
+      "TOOBUSY_FLASHVSR_LATENT"
+    ],
+    [
+      5,
+      5,
+      0,
+      6,
+      0,
+      "IMAGE"
+    ],
+    [
+      6,
+      2,
+      2,
+      6,
+      2,
+      "FLOAT"
+    ],
+    [
+      7,
+      2,
+      1,
+      6,
+      1,
+      "AUDIO"
+    ],
+    [
+      8,
+      6,
+      0,
+      7,
+      0,
+      "VIDEO"
+    ],
+    [
+      9,
+      11,
+      0,
+      4,
+      2,
+      "INT"
+    ],
+    [
+      10,
+      11,
+      1,
+      4,
+      3,
+      "INT"
+    ],
+    [
+      11,
+      11,
+      2,
+      4,
+      4,
+      "INT"
+    ],
+    [
+      12,
+      11,
+      3,
+      4,
+      5,
+      "INT"
+    ],
+    [
+      13,
+      11,
+      4,
+      4,
+      6,
+      "INT"
+    ],
+    [
+      14,
+      11,
+      5,
+      3,
+      0,
+      "BOOLEAN"
+    ],
+    [
+      15,
+      11,
+      6,
+      3,
+      1,
+      "BOOLEAN"
+    ],
+    [
+      16,
+      11,
+      7,
+      5,
+      1,
+      "STRING"
+    ]
   ],
   "groups": [],
   "config": {},
   "extra": {
-    "ds": {"scale": 0.8, "offset": [40, 40]},
+    "ds": {
+      "scale": 0.8,
+      "offset": [
+        40,
+        40
+      ]
+    },
     "frontendVersion": "1.47.12",
     "workflowRendererVersion": "LG"
   },

--- a/flashvsr_node/backend/pipelines/flashvsr_full.py
+++ b/flashvsr_node/backend/pipelines/flashvsr_full.py
@@ -376,6 +376,7 @@ class FlashVSRFullPipeline(BasePipeline):
         local_range = 9,
         color_fix = True,
         offload=False,
+        aggressive_offload=False,
 
     ):
 
@@ -446,6 +447,8 @@ class FlashVSRFullPipeline(BasePipeline):
                         ) if LQ_video is not None else None
                         if cur is None:
                             continue
+                        if aggressive_offload:
+                            cur = [value.cpu() for value in cur]
                         if LQ_latents is None:
                             LQ_latents = cur
                         else:
@@ -469,6 +472,8 @@ class FlashVSRFullPipeline(BasePipeline):
                         ) if LQ_video is not None else None
                         if cur is None:
                             continue
+                        if aggressive_offload:
+                            cur = [value.cpu() for value in cur]
                         if LQ_latents is None:
                             LQ_latents = cur
                         else:
@@ -500,6 +505,7 @@ class FlashVSRFullPipeline(BasePipeline):
                     t=self.t,
                     local_range = local_range,
                     gpu_manager=gpu_manager,
+                    aggressive_offload=aggressive_offload,
                 )
 
                 # 更新 latent
@@ -604,6 +610,7 @@ def model_fn_wan_video(
     t : torch.Tensor = None,
     local_range: int = 9,
     gpu_manager=None,
+    aggressive_offload=False,
     **kwargs,
 ):
     # patchify
@@ -649,18 +656,29 @@ def model_fn_wan_video(
     else:
         for block_id, block in enumerate(dit.blocks):
             if gpu_manager is not None: # apple 1 block to save Vram
+                if block_id > 0 and (block_id - 1) < len(dit.blocks):
+                    prev_module = gpu_manager.managed_modules[block_id - 1]
+                    if hasattr(prev_module, 'to'):
+                        prev_module.to('cpu')
                 if block_id < len(dit.blocks):
                     module = gpu_manager.managed_modules[block_id]
                     if hasattr(module, 'to'):
                         #print(f"move block {block_id} to gpu")
                         module.to(gpu_manager.device)
-                if block_id > 0 and (block_id - 1) < len(dit.blocks):
-                    prev_module = gpu_manager.managed_modules[block_id - 1]
-                    if hasattr(prev_module, 'to'):
-                        prev_module.to('cpu')
 
             if LQ_latents is not None and block_id < len(LQ_latents):
-                x = x + LQ_latents[block_id]
+                lq_latent = LQ_latents[block_id]
+                if aggressive_offload:
+                    lq_latent = lq_latent.to(x.device)
+                x = x + lq_latent
+                del lq_latent
+            cache_k = pre_cache_k[block_id] if pre_cache_k is not None else None
+            cache_v = pre_cache_v[block_id] if pre_cache_v is not None else None
+            if aggressive_offload:
+                if cache_k is not None:
+                    cache_k = cache_k.to(x.device)
+                if cache_v is not None:
+                    cache_v = cache_v.to(x.device)
             x, last_pre_cache_k, last_pre_cache_v = block(
                 x, context, t_mod, freqs, f, h, w,
                 local_num, topk,
@@ -668,12 +686,20 @@ def model_fn_wan_video(
                 kv_len=kv_len,
                 is_full_block=is_full_block,
                 is_stream=is_stream,
-                pre_cache_k=pre_cache_k[block_id] if pre_cache_k is not None else None,
-                pre_cache_v=pre_cache_v[block_id] if pre_cache_v is not None else None,
+                pre_cache_k=cache_k,
+                pre_cache_v=cache_v,
                 local_range = local_range,
             )
+            del cache_k, cache_v
+            if aggressive_offload:
+                if last_pre_cache_k is not None:
+                    last_pre_cache_k = last_pre_cache_k.cpu()
+                if last_pre_cache_v is not None:
+                    last_pre_cache_v = last_pre_cache_v.cpu()
             if pre_cache_k is not None: pre_cache_k[block_id] = last_pre_cache_k
             if pre_cache_v is not None: pre_cache_v[block_id] = last_pre_cache_v
+        if gpu_manager is not None and gpu_manager.managed_modules:
+            gpu_manager.managed_modules[-1].to('cpu')
 
     x = dit.head(x, t)
     if use_unified_sequence_parallel:

--- a/flashvsr_node/backend/runtime.py
+++ b/flashvsr_node/backend/runtime.py
@@ -19,6 +19,7 @@ class FlashVSRModelHandle:
     projection_path: str
     prompt_path: str
     offload: bool
+    aggressive_offload: bool = False
 
 
 def require_block_sparse_attention():
@@ -91,6 +92,7 @@ def load_dit_pipeline(handle):
     pipe.enable_vram_management(num_persistent_param_in_dit=None)
     pipe.init_cross_kv(handle.prompt_path)
     pipe.offload = bool(handle.offload)
+    pipe.aggressive_offload = bool(handle.aggressive_offload)
     return pipe, manager
 
 
@@ -117,6 +119,7 @@ def sample_chunk(pipe, images, seed, scale, kv_ratio, local_range, steps, sparse
         local_range=int(local_range),
         color_fix=True,
         offload=bool(pipe.offload),
+        aggressive_offload=bool(pipe.aggressive_offload),
     )
     if not pipe.offload:
         pipe.dit.to("cpu")
@@ -147,14 +150,31 @@ def _map_to_image(video):
 DECODE_TILE_PRESETS = {
     "safe": ((60, 104), (30, 52)),
     "balanced": ((96, 160), (64, 112)),
-    "fast": ((120, 208), (88, 152)),
+    "fast": ((112, 192), (80, 136)),
 }
+
+
+def decode_tile_settings(tile_preset, samples):
+    if tile_preset != "fast":
+        return DECODE_TILE_PRESETS[tile_preset]
+
+    height, width = (int(value) for value in samples.shape[-2:])
+    overlap = 32
+    if width >= height:
+        tile_height = ((height + overlap + 1) // 2 + 7) // 8 * 8
+        if tile_height * width <= 22528:
+            return (tile_height, width), (tile_height - overlap, width)
+    else:
+        tile_width = ((width + overlap + 1) // 2 + 7) // 8 * 8
+        if height * tile_width <= 22528:
+            return (height, tile_width), (height, tile_width - overlap)
+    return DECODE_TILE_PRESETS[tile_preset]
 
 
 def decode_chunk(pipe, item, tiled, color_fix, tile_preset="safe"):
     samples = item["samples"]
     pipe.vae.clear_cache()
-    tile_size, tile_stride = DECODE_TILE_PRESETS[tile_preset]
+    tile_size, tile_stride = decode_tile_settings(tile_preset, samples)
     decoded = pipe.vae.decode(
         samples,
         device="cuda",

--- a/flashvsr_node/nodes.py
+++ b/flashvsr_node/nodes.py
@@ -19,6 +19,21 @@ from .backend.runtime import (
 MODEL_TYPE = "TOOBUSY_FLASHVSR_MODEL"
 LATENT_TYPE = "TOOBUSY_FLASHVSR_LATENT"
 
+VRAM_PROFILES = {
+    "12GB safe": (True, True, "safe"),
+    "16GB balanced": (True, False, "balanced"),
+    "24GB+ fast": (False, False, "fast"),
+}
+
+RESOLUTION_PRESETS = {
+    "2048x1152 landscape": (1024, 576),
+    "1152x2048 portrait": (576, 1024),
+    "1792x1024 landscape": (896, 512),
+    "1024x1792 portrait": (512, 896),
+    "1536x896 landscape": (768, 448),
+    "896x1536 portrait": (448, 768),
+}
+
 
 def _flashvsr_names(text):
     extensions = (".safetensors", ".ckpt", ".pth", ".pt")
@@ -38,7 +53,8 @@ class ToobusyFlashVSRLoader:
                 "projection": (_flashvsr_names("proj"),),
                 "prompt_tensor": (_flashvsr_names("prompt"),),
                 "offload": ("BOOLEAN", {"default": False}),
-            }
+            },
+            "optional": {"aggressive_offload": ("BOOLEAN", {"default": False})},
         }
 
     RETURN_TYPES = (MODEL_TYPE,)
@@ -46,10 +62,32 @@ class ToobusyFlashVSRLoader:
     FUNCTION = "load"
     CATEGORY = "toobusy/video/FlashVSR"
 
-    def load(self, dit, projection, prompt_tensor, offload):
+    def load(self, dit, projection, prompt_tensor, offload, aggressive_offload=False):
         paths = [folder_paths.get_full_path("toobusy_flashvsr", name) for name in (dit, projection, prompt_tensor)]
         validate_paths(*paths)
-        return (FlashVSRModelHandle(*paths, bool(offload)),)
+        aggressive_offload = bool(aggressive_offload)
+        return (FlashVSRModelHandle(*paths, bool(offload) or aggressive_offload, aggressive_offload),)
+
+
+class ToobusyFlashVSRSettings:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "vram_profile": (list(VRAM_PROFILES), {"default": "24GB+ fast"}),
+                "output_resolution": (list(RESOLUTION_PRESETS), {"default": "2048x1152 landscape"}),
+            }
+        }
+
+    RETURN_TYPES = ("INT", "INT", "INT", "INT", "INT", "BOOLEAN", "BOOLEAN", "STRING")
+    RETURN_NAMES = ("width", "height", "scale", "chunk_frames", "chunk_overlap", "offload", "aggressive_offload", "tile_preset")
+    FUNCTION = "select"
+    CATEGORY = "toobusy/video/FlashVSR"
+
+    def select(self, vram_profile, output_resolution):
+        width, height = RESOLUTION_PRESETS[output_resolution]
+        offload, aggressive_offload, tile_preset = VRAM_PROFILES[vram_profile]
+        return (width, height, 2, 21, 8, offload, aggressive_offload, tile_preset)
 
 
 class ToobusyFlashVSRSampler:
@@ -63,7 +101,7 @@ class ToobusyFlashVSRSampler:
                 "height": ("INT", {"default": 576, "min": 128, "max": 8192, "step": 64}),
                 "scale": ("INT", {"default": 2, "min": 2, "max": 4}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647}),
-                "chunk_frames": ("INT", {"default": 21, "min": 5, "max": 81, "step": 8}),
+                "chunk_frames": ("INT", {"default": 21, "min": 21, "max": 81, "step": 8}),
                 "chunk_overlap": ("INT", {"default": 8, "min": 0, "max": 80}),
                 "local_range": ("INT", {"default": 11, "min": 1, "max": 50}),
                 "kv_ratio": ("FLOAT", {"default": 3.0, "min": 0.0, "max": 10.0, "step": 0.1}),
@@ -142,12 +180,14 @@ class ToobusyFlashVSRDecoder:
 
 NODE_CLASS_MAPPINGS = {
     "ToobusyFlashVSRLoader": ToobusyFlashVSRLoader,
+    "ToobusyFlashVSRSettings": ToobusyFlashVSRSettings,
     "ToobusyFlashVSRSampler": ToobusyFlashVSRSampler,
     "ToobusyFlashVSRDecoder": ToobusyFlashVSRDecoder,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "ToobusyFlashVSRLoader": "toobusy FlashVSR Loader",
+    "ToobusyFlashVSRSettings": "toobusy FlashVSR VRAM & Resolution Preset",
     "ToobusyFlashVSRSampler": "toobusy FlashVSR Long Sampler",
     "ToobusyFlashVSRDecoder": "toobusy FlashVSR Full Decoder",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.1"
+version = "0.4.2"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_flashvsr_settings.py
+++ b/tests/test_flashvsr_settings.py
@@ -1,0 +1,69 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+folder_paths = types.ModuleType("folder_paths")
+folder_paths.get_filename_list = lambda name: ["model.safetensors"]
+folder_paths.get_full_path = lambda name, value: value
+sys.modules["folder_paths"] = folder_paths
+
+torch = types.ModuleType("torch")
+sys.modules["torch"] = torch
+
+comfy = types.ModuleType("comfy")
+comfy_utils = types.ModuleType("comfy.utils")
+comfy_utils.ProgressBar = object
+comfy.utils = comfy_utils
+sys.modules["comfy"] = comfy
+sys.modules["comfy.utils"] = comfy_utils
+
+package = types.ModuleType("flashvsr_node")
+package.__path__ = [str(ROOT / "flashvsr_node")]
+sys.modules["flashvsr_node"] = package
+
+runtime = types.ModuleType("flashvsr_node.backend.runtime")
+
+
+class FlashVSRModelHandle:
+    def __init__(self, dit, projection, prompt, offload, aggressive_offload=False):
+        self.offload = offload
+        self.aggressive_offload = aggressive_offload
+
+
+runtime.FlashVSRModelHandle = FlashVSRModelHandle
+for name in (
+    "chunk_starts",
+    "decode_chunk",
+    "load_dit_pipeline",
+    "load_vae_pipeline",
+    "merge_chunk",
+    "release_pipeline",
+    "resize_images",
+    "sample_chunk",
+    "validate_paths",
+):
+    setattr(runtime, name, lambda *args, **kwargs: None)
+sys.modules["flashvsr_node.backend.runtime"] = runtime
+
+spec = importlib.util.spec_from_file_location("flashvsr_node.nodes", ROOT / "flashvsr_node" / "nodes.py")
+nodes = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = nodes
+spec.loader.exec_module(nodes)
+
+preset = nodes.ToobusyFlashVSRSettings()
+assert preset.select("24GB+ fast", "2048x1152 landscape") == (1024, 576, 2, 21, 8, False, False, "fast")
+assert preset.select("16GB balanced", "1152x2048 portrait") == (576, 1024, 2, 21, 8, True, False, "balanced")
+assert preset.select("12GB safe", "1792x1024 landscape") == (896, 512, 2, 21, 8, True, True, "safe")
+
+loader = nodes.ToobusyFlashVSRLoader()
+handle = loader.load("dit", "projection", "prompt", False, True)[0]
+assert handle.offload is True
+assert handle.aggressive_offload is True
+assert nodes.ToobusyFlashVSRSampler.INPUT_TYPES()["required"]["chunk_frames"][1]["min"] == 21
+
+print("FlashVSR settings tests passed")


### PR DESCRIPTION
Adds 12GB, 16GB, and 24GB+ VRAM profiles with output-resolution presets. Includes aggressive sampler offload, lower-peak block swapping, a faster orientation-aware decoder, and a validated recording workflow.\n\nTests: all local node regression tests, compileall, git diff --check; real 0.8MP-to-FHD 12GB Safe run completed at 8.69GB peak.