### PR TITLE
Fix FlashVSR preset connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [0.4.3] - 2026-08-07
+
+### Fixed
+- Connected the VRAM preset's decoder mode through a dedicated string override
+  input so ComfyUI no longer rejects the workflow as an incompatible combo link.
+
 ## [0.4.2] - 2026-08-07
 
 ### Added

--- a/docs/workflows/flashvsr_v11_full_bsa_long.json
+++ b/docs/workflows/flashvsr_v11_full_bsa_long.json
@@ -251,11 +251,8 @@
           "link": 4
         },
         {
-          "name": "tile_preset",
+          "name": "tile_preset_override",
           "type": "STRING",
-          "widget": {
-            "name": "tile_preset"
-          },
           "link": 16
         }
       ],

--- a/flashvsr_node/nodes.py
+++ b/flashvsr_node/nodes.py
@@ -150,7 +150,10 @@ class ToobusyFlashVSRDecoder:
                 "tiled": ("BOOLEAN", {"default": True}),
                 "color_fix": ("BOOLEAN", {"default": True}),
                 "tile_preset": (["safe", "balanced", "fast"], {"default": "safe"}),
-            }
+            },
+            "optional": {
+                "tile_preset_override": ("STRING", {"forceInput": True}),
+            },
         }
 
     RETURN_TYPES = ("IMAGE",)
@@ -158,7 +161,9 @@ class ToobusyFlashVSRDecoder:
     FUNCTION = "decode"
     CATEGORY = "toobusy/video/FlashVSR"
 
-    def decode(self, flashvsr_latent, vae, tiled, color_fix, tile_preset="safe"):
+    def decode(self, flashvsr_latent, vae, tiled, color_fix, tile_preset="safe", tile_preset_override=None):
+        if tile_preset_override is not None:
+            tile_preset = tile_preset_override
         vae_path = folder_paths.get_full_path("vae", vae)
         validate_paths(vae_path)
         chunks = flashvsr_latent["chunks"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.2"
+version = "0.4.3"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_flashvsr_settings.py
+++ b/tests/test_flashvsr_settings.py
@@ -65,5 +65,7 @@ handle = loader.load("dit", "projection", "prompt", False, True)[0]
 assert handle.offload is True
 assert handle.aggressive_offload is True
 assert nodes.ToobusyFlashVSRSampler.INPUT_TYPES()["required"]["chunk_frames"][1]["min"] == 21
+decoder_inputs = nodes.ToobusyFlashVSRDecoder.INPUT_TYPES()
+assert decoder_inputs["optional"]["tile_preset_override"] == ("STRING", {"forceInput": True})
 
 print("FlashVSR settings tests passed")


### PR DESCRIPTION
Routes the preset decoder mode through a dedicated string override input instead of connecting a string output directly to the combo widget. This removes ComfyUI's invalid-connection error while keeping the decoder dropdown backward compatible.\n\nTests: full local node regression suite, compileall, workflow JSON validation, live Comfy Desktop reload.