### PR TITLE
Fix FlashVSR resample filter direction

### DIFF
--- a/flashvsr_node/backend/runtime.py
+++ b/flashvsr_node/backend/runtime.py
@@ -33,9 +33,24 @@ def require_block_sparse_attention():
     return block_sparse_attn_func
 
 
+def resample_method(source_pixels, target_pixels):
+    """Pick a filter that matches the resize direction.
+
+    `nearest-exact` drops samples without prefiltering, so shrinking aliases and
+    the surviving pixels shift frame to frame once anything moves. That reads as
+    shimmer in the LQ the sampler conditions on. Enlarging is just as bad: pixels
+    get duplicated and the blocky edges become structure the model tries to keep.
+    """
+    return "area" if target_pixels < source_pixels else "bicubic"
+
+
 def resize_images(images, width, height):
+    width = int(width)
+    height = int(height)
     samples = images.movedim(-1, 1)
-    samples = common_upscale(samples, int(width), int(height), "nearest-exact", "center")
+    source_pixels = int(samples.shape[-1]) * int(samples.shape[-2])
+    method = resample_method(source_pixels, width * height)
+    samples = common_upscale(samples, width, height, method, "center")
     return samples.movedim(1, -1).contiguous()
 
 

--- a/tests/test_flashvsr_settings.py
+++ b/tests/test_flashvsr_settings.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.util
 import pathlib
 import sys
@@ -67,5 +68,30 @@ assert handle.aggressive_offload is True
 assert nodes.ToobusyFlashVSRSampler.INPUT_TYPES()["required"]["chunk_frames"][1]["min"] == 21
 decoder_inputs = nodes.ToobusyFlashVSRDecoder.INPUT_TYPES()
 assert decoder_inputs["optional"]["tile_preset_override"] == ("STRING", {"forceInput": True})
+
+# runtime.py drags in torch/PIL/model code, so lift the pure helper out by AST
+# instead of importing the module.
+runtime_source = (ROOT / "flashvsr_node" / "backend" / "runtime.py").read_text(encoding="utf-8")
+resample_fn = next(
+    node
+    for node in ast.parse(runtime_source).body
+    if isinstance(node, ast.FunctionDef) and node.name == "resample_method"
+)
+resample_ns = {}
+exec(compile(ast.Module(body=[resample_fn], type_ignores=[]), "<resample_method>", "exec"), resample_ns)
+resample_method = resample_ns["resample_method"]
+
+# shrinking must prefilter, enlarging must interpolate; nearest-exact does neither
+assert resample_method(1280 * 720, 1024 * 576) == "area"
+assert resample_method(1192 * 670, 1024 * 576) == "area"
+assert resample_method(832 * 480, 1024 * 576) == "bicubic"
+# equal pixel counts are a no-op resize; bicubic leaves them untouched
+assert resample_method(1024 * 576, 1024 * 576) == "bicubic"
+# never hand common_upscale the unfiltered path again
+assert all(
+    resample_method(src, dst) in ("area", "bicubic")
+    for src in (399360, 589824, 921600, 2073600)
+    for dst in (399360, 589824, 921600, 2073600)
+)
 
 print("FlashVSR settings tests passed")


### PR DESCRIPTION
## 문제

`runtime.py:resize_images`가 축소·확대 양쪽 모두 `nearest-exact`를 씁니다.

```python
common_upscale(samples, int(width), int(height), "nearest-exact", "center")
```

- **축소**: 프리필터 없이 샘플을 버려서 에일리어싱. 움직임이 있으면 살아남는 픽셀이 프레임마다 바뀌어 셔머링이 생기고, 샘플러가 그 흔들리는 LQ를 조건으로 받습니다.
- **확대**: 픽셀을 복제해 계단이 생기고, 모델이 그 계단을 보존해야 할 구조로 인식합니다.

에일리어싱이 **모델에 들어가기 전에** 발생하므로 디퓨전이 이를 복원 대상으로 착각해 증폭합니다.

## 왜 지금까지 안 드러났나

기본 워크플로우의 테스트 소스가 0.6MP(약 1032x581)라 타깃 1024x576과 거의 같습니다. 리사이즈가 사실상 no-op이라 필터 종류가 결과에 영향을 주지 않았습니다. 0.8MP(1192x670)나 1280x720 소스에서 드러납니다.

## 수정

방향에 맞는 필터를 고릅니다 — 축소는 `area`, 확대는 `bicubic`.

## 영향 범위

작업 해상도와 텐서 크기는 **변경 없음**. 따라서 실측으로 튜닝된 12/16/24GB VRAM 프로필과 출력 해상도는 영향받지 않습니다. 보간 방식만 바뀝니다.

## 검증

- 전체 19개 테스트 스위트 green
- `py_compile` OK
- `resample_method` 단위 검증 추가 (`runtime.py`가 torch/PIL 의존이라 AST로 순수 함수만 추출)

GPU 스모크(문제 클립 전/후 비교)는 3090 미니PC에서 진행 예정. **검증 전까지 태그/Registry 발행 없음.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)