### PR TITLE
Release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [0.4.4] - 2026-08-07
+
+### Fixed
+- FlashVSR now resamples with a filter that matches the resize direction: `area`
+  when shrinking the source, `bicubic` when enlarging it. Both directions
+  previously used `nearest-exact`, which drops samples without prefiltering, so
+  shrinking aliased and the surviving pixels shifted from frame to frame once
+  anything moved — the sampler was conditioned on a shimmering low-quality
+  input. Enlarging duplicated pixels into blocky edges the model then preserved.
+  Sources close to the selected working resolution were barely affected, which
+  is why the issue only showed up on larger inputs such as 0.8MP or 1280x720.
+  Working resolution and tensor sizes are unchanged, so the verified 12GB, 16GB,
+  and 24GB+ VRAM profiles still apply.
+
 ## [0.4.3] - 2026-08-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.3"
+version = "0.4.4"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
FlashVSR 리샘플 필터 수정([#107](https://github.com/nicekriss/toobusy/pull/107))을 `v0.4.4`로 발행합니다. 코드 변경은 이미 main에 있고, 이 PR은 버전 범프와 CHANGELOG만 담습니다.

## 내용

`resize_images`가 축소·확대 양쪽에 `nearest-exact`를 쓰던 것을 방향에 맞는 필터로 교체 — 축소 `area`, 확대 `bicubic`.

## 영향 범위

작업 해상도와 텐서 크기는 변경 없음. 실측으로 튜닝된 12/16/24GB VRAM 프로필과 출력 해상도는 영향받지 않습니다.

## 검증

- 전체 19개 테스트 스위트 green, `py_compile` OK (#107에서 확인)
- GPU 스모크는 발행 후 3090 미니PC에서 진행 예정 — 해당 머신이 Registry 설치본이라 이 순서로 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)