### PR TITLE
Remove Registry exec warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.6] - 2026-08-10
+
+### Changed
+- Reworked the FlashVSR source inspection test to avoid dynamic `exec`, keeping
+  Registry security scans clean without changing installed node behavior.
+
 ## [0.4.5] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > **Fold the graph.** — toobusy folds tedious multi-step ComfyUI workflows into single production nodes.
 
-현재 문서는 **v0.4.5** 기준입니다.
+현재 문서는 **v0.4.6** 기준입니다.
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.5"
+version = "0.4.6"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_flashvsr_settings.py
+++ b/tests/test_flashvsr_settings.py
@@ -77,21 +77,7 @@ resample_fn = next(
     for node in ast.parse(runtime_source).body
     if isinstance(node, ast.FunctionDef) and node.name == "resample_method"
 )
-resample_ns = {}
-exec(compile(ast.Module(body=[resample_fn], type_ignores=[]), "<resample_method>", "exec"), resample_ns)
-resample_method = resample_ns["resample_method"]
-
-# shrinking must prefilter, enlarging must interpolate; nearest-exact does neither
-assert resample_method(1280 * 720, 1024 * 576) == "area"
-assert resample_method(1192 * 670, 1024 * 576) == "area"
-assert resample_method(832 * 480, 1024 * 576) == "bicubic"
-# equal pixel counts are a no-op resize; bicubic leaves them untouched
-assert resample_method(1024 * 576, 1024 * 576) == "bicubic"
-# never hand common_upscale the unfiltered path again
-assert all(
-    resample_method(src, dst) in ("area", "bicubic")
-    for src in (399360, 589824, 921600, 2073600)
-    for dst in (399360, 589824, 921600, 2073600)
-)
+return_node = next(node for node in resample_fn.body if isinstance(node, ast.Return))
+assert ast.unparse(return_node.value) == "'area' if target_pixels < source_pixels else 'bicubic'"
 
 print("FlashVSR settings tests passed")


### PR DESCRIPTION
## What changed

- replace a test-only dynamic `exec` with direct AST inspection
- bump the Registry package to `0.4.6`

## Why

The Comfy Registry scanner accepted `0.4.5` but warned that dynamic `exec` will be rejected in a future release. The call was only used by a source-inspection test and is unnecessary.

## Validation

- FlashVSR settings test passed
- Wan Animate 2 long-sampler tests passed
- no dynamic `exec` calls remain
