### PR TITLE
Fix FlashVSR short video alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [Unreleased]
+
+### Added
+- Added a 32GB aggressive VRAM profile and 128-aligned high-resolution presets.
+
+### Fixed
+- Padded short FlashVSR inputs to the minimum 25-frame streaming layout and
+  rejected misaligned LQ input before it can lose tail guidance.
+
 ## [0.4.4] - 2026-08-07
 
 ### Fixed
@@ -37,7 +46,6 @@
   is why the issue only showed up on larger inputs such as 0.8MP or 1280x720.
   Working resolution and tensor sizes are unchanged, so the verified 12GB, 16GB,
   and 24GB+ VRAM profiles still apply.
-
 ## [0.4.3] - 2026-08-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
-## [Unreleased]
+## [0.4.7] - 2026-08-14
 
 ### Added
 - Added a 32GB aggressive VRAM profile and 128-aligned high-resolution presets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 ### Fixed
 - Padded short FlashVSR inputs to the minimum 25-frame streaming layout and
   rejected misaligned LQ input before it can lose tail guidance.
+- Ignored placeholder FlashAttention modules that do not expose a callable
+  attention function, allowing the installed fallback backend to be selected.
 
 ## [0.4.4] - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Get Video Components
 
 - 검증 프리셋: `2x`, `1024x576`, `chunk_frames=21`, `chunk_overlap=8`, Full VAE tiled, BSA.
 - 검증 환경: Windows, RTX 3090 24GB, Python 3.13, PyTorch 2.12.1+cu130.
-- VRAM 프리셋: 12GB는 aggressive offload + Safe decode, 16GB는 standard offload + Balanced decode, 24GB+는 GPU resident + orientation-aware Fast decode를 사용합니다.
-- 해상도 프리셋은 최종 출력 크기를 표시하며 샘플러에는 2배 업스케일 전 기준 크기를 전달합니다.
+- VRAM 프리셋: 12GB는 aggressive offload + Safe decode, 16GB는 standard offload + Balanced decode, 24GB+는 GPU resident + orientation-aware Fast decode를 사용합니다. 32GB aggressive는 고해상도 작업을 위해 aggressive offload + Balanced decode를 사용합니다.
+- 해상도 프리셋은 최종 출력 크기를 표시하며 샘플러에는 2배 업스케일 전 기준 크기를 전달합니다. 고해상도 프리셋은 내부 128배수 크롭과 실제 출력값이 일치하도록 표기합니다.
 - 샘플러가 DiT만 로드한 뒤 CPU latent를 만들고 해제하며, 디코더가 그 다음 VAE만 로드합니다. 실행 사이에 GPU 모델을 전역 캐시하지 않습니다.
 - 모델 자동 다운로드는 하지 않습니다. 아래 파일을 직접 배치해야 합니다.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > **Fold the graph.** — toobusy folds tedious multi-step ComfyUI workflows into single production nodes.
 
-현재 문서는 **v0.4.6** 기준입니다.
+현재 문서는 **v0.4.7** 기준입니다.
 
 ## Quick Start
 

--- a/flashvsr_node/backend/examples/WanVSR/utils/utils.py
+++ b/flashvsr_node/backend/examples/WanVSR/utils/utils.py
@@ -374,7 +374,7 @@ class Causal_LQ4x_Proj(nn.Module):
             return outputs
 
 def calculate_frame_adjustment_simple(original_frames):
-    input_frames = original_frames
+    input_frames = max(original_frames, 21)
 
     # 持续增加输入帧数直到满足输出要求
     while True:

--- a/flashvsr_node/backend/models/wan_video_dit.py
+++ b/flashvsr_node/backend/models/wan_video_dit.py
@@ -11,13 +11,13 @@ from .utils import hash_state_dict_keys
 
 try:
     import flash_attn_interface
-    FLASH_ATTN_3_AVAILABLE = True
+    FLASH_ATTN_3_AVAILABLE = callable(getattr(flash_attn_interface, "flash_attn_func", None))
 except ModuleNotFoundError:
     FLASH_ATTN_3_AVAILABLE = False
 
 try:
     import flash_attn
-    FLASH_ATTN_2_AVAILABLE = True
+    FLASH_ATTN_2_AVAILABLE = callable(getattr(flash_attn, "flash_attn_func", None))
 except ModuleNotFoundError:
     FLASH_ATTN_2_AVAILABLE = False
 

--- a/flashvsr_node/backend/pipelines/flashvsr_full.py
+++ b/flashvsr_node/backend/pipelines/flashvsr_full.py
@@ -399,7 +399,13 @@ class FlashVSRFullPipeline(BasePipeline):
                 "    pipe.init_cross_kv(context_tensor=your_context_tensor)"
             )
 
-        if num_frames % 4 != 1:
+        if LQ_video is not None:
+            lq_frames = int(LQ_video.shape[2])
+            if lq_frames != num_frames:
+                raise ValueError(f"LQ_video has {lq_frames} frames, but num_frames is {num_frames}.")
+            if lq_frames < 25 or lq_frames % 8 != 1:
+                raise ValueError("FlashVSR LQ_video must contain at least 25 frames and follow the 8n+1 frame layout.")
+        elif num_frames % 4 != 1:
             num_frames = (num_frames + 2) // 4 * 4 + 1
             print(f"Only `num_frames % 4 != 1` is acceptable. We round it up to {num_frames}.")
 

--- a/flashvsr_node/nodes.py
+++ b/flashvsr_node/nodes.py
@@ -23,6 +23,7 @@ VRAM_PROFILES = {
     "12GB safe": (True, True, "safe"),
     "16GB balanced": (True, False, "balanced"),
     "24GB+ fast": (False, False, "fast"),
+    "32GB aggressive": (True, True, "balanced"),
 }
 
 RESOLUTION_PRESETS = {
@@ -32,6 +33,16 @@ RESOLUTION_PRESETS = {
     "1024x1792 portrait": (512, 896),
     "1536x896 landscape": (768, 448),
     "896x1536 portrait": (448, 768),
+    "4096x2304 landscape (4K+)": (2048, 1152),
+    "2304x4096 portrait (4K+)": (1152, 2048),
+    "3840x2176 landscape (UHD aligned)": (1920, 1088),
+    "2176x3840 portrait (UHD aligned)": (1088, 1920),
+    "3072x1792 landscape (3K aligned)": (1536, 896),
+    "1792x3072 portrait (3K aligned)": (896, 1536),
+    "2560x1408 landscape (QHD aligned)": (1280, 704),
+    "1408x2560 portrait (QHD aligned)": (704, 1280),
+    "1920x1024 landscape (FHD aligned)": (960, 512),
+    "1024x1920 portrait (FHD aligned)": (512, 960),
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.6"
+version = "0.4.7"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_flashvsr_frame_adjustment.py
+++ b/tests/test_flashvsr_frame_adjustment.py
@@ -1,0 +1,29 @@
+import ast
+import pathlib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+UTILS = ROOT / "flashvsr_node" / "backend" / "examples" / "WanVSR" / "utils" / "utils.py"
+
+tree = ast.parse(UTILS.read_text(encoding="utf-8"))
+adjust = next(
+    node
+    for node in tree.body
+    if isinstance(node, ast.FunctionDef) and node.name == "calculate_frame_adjustment_simple"
+)
+input_frames = next(
+    node
+    for node in adjust.body
+    if isinstance(node, ast.Assign) and ast.unparse(node.targets[0]) == "input_frames"
+)
+assert ast.unparse(input_frames.value) == "max(original_frames, 21)"
+
+assignments = {
+    ast.unparse(node.targets[0]): ast.unparse(node.value)
+    for node in adjust.body
+    if isinstance(node, ast.Assign)
+}
+assert assignments["frames_to_add"] == "input_frames + 4 - original_frames"
+assert assignments["frames_to_remove"] == "output_frames - original_frames"
+
+print("FlashVSR frame adjustment tests passed")

--- a/tests/test_flashvsr_settings.py
+++ b/tests/test_flashvsr_settings.py
@@ -60,6 +60,11 @@ preset = nodes.ToobusyFlashVSRSettings()
 assert preset.select("24GB+ fast", "2048x1152 landscape") == (1024, 576, 2, 21, 8, False, False, "fast")
 assert preset.select("16GB balanced", "1152x2048 portrait") == (576, 1024, 2, 21, 8, True, False, "balanced")
 assert preset.select("12GB safe", "1792x1024 landscape") == (896, 512, 2, 21, 8, True, True, "safe")
+assert preset.select("32GB aggressive", "4096x2304 landscape (4K+)") == (2048, 1152, 2, 21, 8, True, True, "balanced")
+assert preset.select("24GB+ fast", "3840x2176 landscape (UHD aligned)")[:2] == (1920, 1088)
+assert preset.select("24GB+ fast", "2176x3840 portrait (UHD aligned)")[:2] == (1088, 1920)
+assert preset.select("24GB+ fast", "2560x1408 landscape (QHD aligned)")[:2] == (1280, 704)
+assert preset.select("24GB+ fast", "1920x1024 landscape (FHD aligned)")[:2] == (960, 512)
 
 loader = nodes.ToobusyFlashVSRLoader()
 handle = loader.load("dit", "projection", "prompt", False, True)[0]


### PR DESCRIPTION
## What changed
- Pad short FlashVSR inputs to the minimum 25-frame `8n+1` streaming layout and trim the generated padding from the final output.
- Reject misaligned LQ input before it can lose tail guidance.
- Ignore placeholder FlashAttention modules without a callable attention function, preserving BSA for self-attention while allowing the cross-attention fallback backend to load.
- Add a 32GB aggressive profile and output-size-accurate 128-aligned high-resolution presets.

## Why
Short inputs could produce invalid temporal slices, and another installed custom node could register a placeholder `flash_attn` module that FlashVSR incorrectly treated as usable.

## Validation
- `python tests/test_flashvsr_settings.py`
- `python tests/test_flashvsr_frame_adjustment.py`
- `python -m compileall -q flashvsr_node`
- Live ComfyUI run: 12-frame input padded to 25 frames, completed sampler + balanced decoder, and produced exactly 12 frames at 1024x1024 / 24 fps / 0.5 s.