### PR TITLE
Fix optional FlashVSR dependency loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [0.4.10] - 2026-09-01
+
+### Fixed
+- Stopped the optional FlashVSR `diffusers` dependency from aborting the entire
+  package import, so unrelated nodes such as the MiniMax H3 helpers still load
+  on a clean ComfyUI installation.
+
 ## [0.4.9] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > **Fold the graph.** — toobusy folds tedious multi-step ComfyUI workflows into single production nodes.
 
-현재 문서는 **v0.4.9** 기준입니다.
+현재 문서는 **v0.4.10** 기준입니다.
 
 ## Quick Start
 

--- a/flashvsr_node/backend/pipelines/flashvsr_full.py
+++ b/flashvsr_node/backend/pipelines/flashvsr_full.py
@@ -17,7 +17,6 @@ from ..models.wan_video_dit import WanModel, RMSNorm, sinusoidal_embedding_1d
 from ..models.wan_video_vae import WanVideoVAE, RMS_norm, CausalConv3d, Upsample
 from ..schedulers.flow_match import FlowMatchScheduler
 from .base import BasePipeline
-from diffusers import AutoencoderKLWan
 from safetensors.torch import load_file
 # -----------------------------
 # 基础工具：ADAIN 所需的统计量（保留以备需要；管线默认用 wavelet）
@@ -328,7 +327,7 @@ class FlashVSRFullPipeline(BasePipeline):
 
                 frames=self.VAE.decode(latents.squeeze(0))
         else:
-            if isinstance(self.vae,AutoencoderKLWan) :
+            if self.vae.__class__.__name__ == "AutoencoderKLWan":
                 latents_mean = (
                 torch.tensor(self.vae.config.latents_mean)
                     .view(1, self.vae.config.z_dim, 1, 1, 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.9"
+version = "0.4.10"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/requirements_flashvsr.txt
+++ b/requirements_flashvsr.txt
@@ -1,6 +1,5 @@
 # Install the Block-Sparse Attention wheel that exactly matches Python, PyTorch, and CUDA.
 # Tested: Python 3.13, PyTorch 2.12.1+cu130, CUDA 13.0 on Windows.
-diffusers
 einops
 numpy
 pillow

--- a/tests/test_flashvsr_optional_diffusers.py
+++ b/tests/test_flashvsr_optional_diffusers.py
@@ -1,0 +1,22 @@
+import ast
+import pathlib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PIPELINE = ROOT / "flashvsr_node" / "backend" / "pipelines" / "flashvsr_full.py"
+
+tree = ast.parse(PIPELINE.read_text(encoding="utf-8"))
+assert not any(
+    isinstance(node, ast.ImportFrom) and node.module == "diffusers"
+    for node in tree.body
+)
+assert "AutoencoderKLWan" in {
+    node.value
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Constant) and isinstance(node.value, str)
+}
+
+requirements = (ROOT / "requirements_flashvsr.txt").read_text(encoding="utf-8").splitlines()
+assert "diffusers" not in {line.strip() for line in requirements}
+
+print("FlashVSR optional diffusers tests passed")


### PR DESCRIPTION
## Problem
A missing optional `diffusers` install made the FlashVSR module fail during root package import, which prevented unrelated nodes such as the MiniMax H3 helpers from registering.

## Change
- remove the eager type-only `diffusers` import
- keep AutoencoderKLWan detection without importing the optional package
- remove `diffusers` from FlashVSR requirements
- bump the package to 0.4.10

## Tests
- full Python test suite with UTF-8 mode
- compileall across node packages
- esbuild syntax check for all JavaScript files
