### PR TITLE
Harden node registration and remove unsafe deserialization (v0.4.11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Byte-compile all node packages
+      - name: Byte-compile every node package
         run: |
-          python -m compileall -q \
-            __init__.py \
-            flashvsr_node \
-            hires_upscale_node \
-            load_clip_node \
-            ideogram4_t2i_node \
-            ideogram_layout_builder \
-            ideogram_prompt_polish_node \
-            keyframe_maker_node \
-            layout_text_overlay_node \
-            ltx23_compact_sampler_node \
-            minimax_h3_image_latent_node \
-            minimax_h3_optional_reference_node \
-            minimax_h3_semantic_reference_node \
-            paint_canvas_node \
-            storyboard_board_node \
-            wan_animate2_long_sampler_node \
-            wan_scail_extend_sampler_node \
-            z_image_turbo_node \
-            zit_controlnet_node
+          # Compile the whole repository so a newly added package can never be
+          # left out of this list the way it was before v0.4.11.
+          python -m compileall -q .
       - name: Node behaviour regression tests (no ComfyUI runtime)
         run: |
           for f in tests/test_*.py; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 이 프로젝트의 주요 변경 사항을 기록합니다. (Keep a Changelog 형식, 날짜는 YYYY-MM-DD)
 
+## [0.4.11] - 2026-09-07
+
+### Security
+- `torch.load`는 이제 모든 호출부에서 `weights_only=True`를 씁니다. FlashVSR
+  백엔드의 `LQ_proj_in` 프로젝션과 `posi_prompt` 텐서를 읽던 두 곳이 임의 pickle을
+  역직렬화할 수 있었습니다. 두 체크포인트 모두 `weights_only=True`로 동일하게
+  로드되는 것을 실제 파일로 확인했습니다.
+
+### Fixed
+- 선택 의존성이 없는 패키지 하나가 toobusy 노드 **전체**를 사라지게 만들던 문제를
+  구조적으로 막았습니다. 이제 하위 패키지를 각각 격리해서 임포트하고, 실패한
+  패키지만 건너뛴 뒤 이유를 ComfyUI 시작 로그에 남깁니다
+  (`[toobusy] skipped node package ...`).
+- cp949/cp932 콘솔(한국어·일본어 Windows)에서 `UnicodeEncodeError`로 노드 실행이
+  중단되던 `print()` 9곳의 em dash를 ASCII로 바꿨습니다.
+- FlashVSR의 모델 폴더 등록이 임포트 시점에 실패하면 패키지가 통째로 죽던 것을
+  막고 경고만 남기도록 했습니다.
+
+### Changed
+- CI가 저장소 전체를 바이트컴파일합니다. 이전에는 수동으로 나열한 목록에서
+  7개 패키지가 빠져 있었습니다.
+- `tests/test_package_registration.py` 추가: 등록되지 않은 노드 패키지, 표시
+  이름이 없는 노드, 격리되지 않은 임포트, `weights_only=True`가 아닌 `torch.load`,
+  ASCII가 아닌 콘솔 출력을 정적으로 검사합니다.
+
+### Note
+- Comfy Registry에서 0.4.9와 0.4.10이 `Banned` 상태라 ComfyUI Manager는 계속
+  0.4.8을 설치합니다. 그래서 `toobusy MiniMax H3 Semantic Reference`가 노드
+  목록에 나타나지 않습니다. 해결될 때까지는 `git clone` 또는 Manager의
+  **Install via Git URL** 로 설치하세요.
+
 ## [0.4.10] - 2026-09-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > **Fold the graph.** — toobusy folds tedious multi-step ComfyUI workflows into single production nodes.
 
-현재 문서는 **v0.4.10** 기준입니다.
+현재 문서는 **v0.4.11** 기준입니다.
 
 ## Quick Start
 
@@ -22,6 +22,13 @@ git pull
 ```
 
 ComfyUI를 재시작하세요. 프런트엔드(JS) 변경을 받은 뒤에는 브라우저를 강력 새로고침(hard refresh) 하는 것을 권장합니다.
+
+> **ComfyUI Manager로 설치할 때 주의.** Manager는 Comfy Registry에 올라간 버전을 받아옵니다.
+> 지금은 0.4.9 / 0.4.10이 레지스트리에서 내려가 있어서 Manager로 설치하면 **0.4.8**이 깔리고,
+> 0.4.9에서 추가된 MiniMax H3 캐릭터시트 노드들이 노드 목록에 나오지 않습니다.
+> 설치는 성공하고 다른 노드도 정상 동작하므로 원인을 찾기 어렵습니다.
+> 최신 노드가 필요하면 위의 `git clone`을 쓰거나 Manager의 **Install via Git URL**에
+> `https://github.com/nicekriss/toobusy` 를 넣으세요.
 
 ### MiniMax H3 Single-Image Editing
 
@@ -390,6 +397,28 @@ v0.2.10부터 파일명 퍼지 스캔으로 Z-Image 모델/텍스트 인코더/V
 ### Load CLIP으로 Llama/Dolphin GGUF를 로드했는데 Text Generate가 안 됩니다.
 
 로드 자체와 `generate()` 지원은 다릅니다. ComfyUI 래퍼상 Text Generate 프롬프트 인핸서로는 Gemma 계열이 가장 안전합니다.
+
+### 노드 목록에 `toobusy MiniMax H3 Semantic Reference`가 없습니다.
+
+설치된 버전이 0.4.8 이하입니다. 이 노드는 **0.4.9에서 추가**됐습니다.
+패키지는 오류 없이 설치되고 나머지 toobusy 노드도 전부 정상 동작하기 때문에
+설치 실패처럼 보이지 않는 것이 함정입니다. 재설치해도 같은 0.4.8을 다시 받습니다.
+
+| 노드 | 처음 들어간 버전 |
+| --- | --- |
+| `toobusy MiniMax H3 Image Latent` | v0.4.8 |
+| `toobusy MiniMax H3 Semantic Reference` | v0.4.9 |
+| `toobusy MiniMax H3 Reference Manifest` | v0.4.9 |
+| `toobusy MiniMax H3 Optional Reference` | v0.4.9 |
+
+`custom_nodes/toobusy/pyproject.toml`의 `version` 값으로 설치된 버전을 확인할 수 있습니다.
+해결은 위 Quick Start의 `git clone` 또는 Manager의 **Install via Git URL** 입니다.
+
+### toobusy 노드가 하나도 안 보입니다.
+
+v0.4.11부터는 선택 의존성이 빠져도 **그 패키지 하나만** 빠지고 나머지 노드는 그대로 로드됩니다.
+그래도 전부 안 보인다면 ComfyUI 시작 로그에서 `[toobusy] skipped node package ...` 줄을 찾으세요.
+어떤 패키지가 왜 빠졌는지와, 어떤 `requirements_*.txt`를 설치해야 하는지가 그 줄에 나옵니다.
 
 ### 워크플로우 JSON이 너무 커집니다.
 

--- a/__init__.py
+++ b/__init__.py
@@ -3,163 +3,350 @@
 This repository is intended to be cloned into ComfyUI's `custom_nodes` folder
 (e.g. `custom_nodes/toobusy`). ComfyUI imports that folder as a Python package,
 so this top-level `__init__.py` must expose node mappings.
+
+Each sub-package is imported in isolation. A package that cannot be imported --
+usually because one of its optional dependencies is missing -- is skipped on its
+own, and every other toobusy node still reaches ComfyUI. The skipped packages
+are reported once at the end of this module so the reason shows up in the
+ComfyUI startup log instead of silently removing the whole node set.
 """
 
-from .ltx23_compact_sampler_node import (
-    NODE_CLASS_MAPPINGS as LTX23_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as LTX23_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .keyframe_maker_node import (
-    NODE_CLASS_MAPPINGS as KEYFRAME_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as KEYFRAME_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .z_image_turbo_node import (
-    NODE_CLASS_MAPPINGS as Z_IMAGE_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as Z_IMAGE_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .storyboard_board_node import (
-    NODE_CLASS_MAPPINGS as STORYBOARD_BOARD_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as STORYBOARD_BOARD_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .ideogram_layout_builder import (
-    NODE_CLASS_MAPPINGS as IDEOGRAM_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as IDEOGRAM_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .ideogram4_t2i_node import (
-    NODE_CLASS_MAPPINGS as IDEOGRAM4_T2I_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as IDEOGRAM4_T2I_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .ideogram_prompt_polish_node import (
-    NODE_CLASS_MAPPINGS as PROMPT_POLISH_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as PROMPT_POLISH_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .wan_scail_extend_sampler_node import (
-    NODE_CLASS_MAPPINGS as WAN_SCAIL_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as WAN_SCAIL_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .wan_animate2_long_sampler_node import (
-    NODE_CLASS_MAPPINGS as WAN_ANIMATE2_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as WAN_ANIMATE2_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .hires_upscale_node import (
-    NODE_CLASS_MAPPINGS as HIRES_UPSCALE_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as HIRES_UPSCALE_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .zit_controlnet_node import (
-    NODE_CLASS_MAPPINGS as ZIT_CONTROLNET_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as ZIT_CONTROLNET_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .paint_canvas_node import (
-    NODE_CLASS_MAPPINGS as PAINT_CANVAS_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as PAINT_CANVAS_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .load_clip_node import (
-    NODE_CLASS_MAPPINGS as LOAD_CLIP_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as LOAD_CLIP_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .flux2_klein_node import (
-    NODE_CLASS_MAPPINGS as FLUX2_KLEIN_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as FLUX2_KLEIN_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .flux2_klein_prompt_director_node import (
-    NODE_CLASS_MAPPINGS as FLUX2_KLEIN_PROMPT_DIRECTOR_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as FLUX2_KLEIN_PROMPT_DIRECTOR_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .reference_board_node import (
-    NODE_CLASS_MAPPINGS as REFERENCE_BOARD_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as REFERENCE_BOARD_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .dreamid_omni_node import (
-    NODE_CLASS_MAPPINGS as DREAMID_OMNI_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as DREAMID_OMNI_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .bundle_tools_node import (
-    NODE_CLASS_MAPPINGS as BUNDLE_TOOLS_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as BUNDLE_TOOLS_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .layout_text_overlay_node import (
-    NODE_CLASS_MAPPINGS as LAYOUT_TEXT_OVERLAY_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as LAYOUT_TEXT_OVERLAY_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .background_remove_node import (
-    NODE_CLASS_MAPPINGS as BACKGROUND_REMOVE_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as BACKGROUND_REMOVE_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .face_mask_node import (
-    NODE_CLASS_MAPPINGS as FACE_MASK_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as FACE_MASK_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .flashvsr_node import (
-    NODE_CLASS_MAPPINGS as FLASHVSR_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as FLASHVSR_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .minimax_h3_image_latent_node import (
-    NODE_CLASS_MAPPINGS as MINIMAX_H3_IMAGE_LATENT_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as MINIMAX_H3_IMAGE_LATENT_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .minimax_h3_optional_reference_node import (
-    NODE_CLASS_MAPPINGS as MINIMAX_H3_OPTIONAL_REFERENCE_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as MINIMAX_H3_OPTIONAL_REFERENCE_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .minimax_h3_semantic_reference_node import (
-    NODE_CLASS_MAPPINGS as MINIMAX_H3_SEMANTIC_REFERENCE_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as MINIMAX_H3_SEMANTIC_REFERENCE_NODE_DISPLAY_NAME_MAPPINGS,
-)
+import logging
 
-NODE_CLASS_MAPPINGS = {
-    **LTX23_NODE_CLASS_MAPPINGS,
-    **KEYFRAME_NODE_CLASS_MAPPINGS,
-    **Z_IMAGE_NODE_CLASS_MAPPINGS,
-    **STORYBOARD_BOARD_NODE_CLASS_MAPPINGS,
-    **IDEOGRAM_NODE_CLASS_MAPPINGS,
-    **IDEOGRAM4_T2I_NODE_CLASS_MAPPINGS,
-    **PROMPT_POLISH_NODE_CLASS_MAPPINGS,
-    **WAN_SCAIL_NODE_CLASS_MAPPINGS,
-    **WAN_ANIMATE2_NODE_CLASS_MAPPINGS,
-    **HIRES_UPSCALE_NODE_CLASS_MAPPINGS,
-    **ZIT_CONTROLNET_NODE_CLASS_MAPPINGS,
-    **PAINT_CANVAS_NODE_CLASS_MAPPINGS,
-    **FLUX2_KLEIN_NODE_CLASS_MAPPINGS,
-    **FLUX2_KLEIN_PROMPT_DIRECTOR_NODE_CLASS_MAPPINGS,
-    **REFERENCE_BOARD_NODE_CLASS_MAPPINGS,
-    **DREAMID_OMNI_NODE_CLASS_MAPPINGS,
-    **BUNDLE_TOOLS_NODE_CLASS_MAPPINGS,
-    **LOAD_CLIP_NODE_CLASS_MAPPINGS,
-    **LAYOUT_TEXT_OVERLAY_NODE_CLASS_MAPPINGS,
-    **BACKGROUND_REMOVE_NODE_CLASS_MAPPINGS,
-    **FACE_MASK_NODE_CLASS_MAPPINGS,
-    **FLASHVSR_NODE_CLASS_MAPPINGS,
-    **MINIMAX_H3_IMAGE_LATENT_NODE_CLASS_MAPPINGS,
-    **MINIMAX_H3_OPTIONAL_REFERENCE_NODE_CLASS_MAPPINGS,
-    **MINIMAX_H3_SEMANTIC_REFERENCE_NODE_CLASS_MAPPINGS,
-}
+logger = logging.getLogger(__name__)
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    **LTX23_NODE_DISPLAY_NAME_MAPPINGS,
-    **KEYFRAME_NODE_DISPLAY_NAME_MAPPINGS,
-    **Z_IMAGE_NODE_DISPLAY_NAME_MAPPINGS,
-    **STORYBOARD_BOARD_NODE_DISPLAY_NAME_MAPPINGS,
-    **IDEOGRAM_NODE_DISPLAY_NAME_MAPPINGS,
-    **IDEOGRAM4_T2I_NODE_DISPLAY_NAME_MAPPINGS,
-    **PROMPT_POLISH_NODE_DISPLAY_NAME_MAPPINGS,
-    **WAN_SCAIL_NODE_DISPLAY_NAME_MAPPINGS,
-    **WAN_ANIMATE2_NODE_DISPLAY_NAME_MAPPINGS,
-    **HIRES_UPSCALE_NODE_DISPLAY_NAME_MAPPINGS,
-    **ZIT_CONTROLNET_NODE_DISPLAY_NAME_MAPPINGS,
-    **PAINT_CANVAS_NODE_DISPLAY_NAME_MAPPINGS,
-    **FLUX2_KLEIN_NODE_DISPLAY_NAME_MAPPINGS,
-    **FLUX2_KLEIN_PROMPT_DIRECTOR_NODE_DISPLAY_NAME_MAPPINGS,
-    **REFERENCE_BOARD_NODE_DISPLAY_NAME_MAPPINGS,
-    **DREAMID_OMNI_NODE_DISPLAY_NAME_MAPPINGS,
-    **BUNDLE_TOOLS_NODE_DISPLAY_NAME_MAPPINGS,
-    **LOAD_CLIP_NODE_DISPLAY_NAME_MAPPINGS,
-    **LAYOUT_TEXT_OVERLAY_NODE_DISPLAY_NAME_MAPPINGS,
-    **BACKGROUND_REMOVE_NODE_DISPLAY_NAME_MAPPINGS,
-    **FACE_MASK_NODE_DISPLAY_NAME_MAPPINGS,
-    **FLASHVSR_NODE_DISPLAY_NAME_MAPPINGS,
-    **MINIMAX_H3_IMAGE_LATENT_NODE_DISPLAY_NAME_MAPPINGS,
-    **MINIMAX_H3_OPTIONAL_REFERENCE_NODE_DISPLAY_NAME_MAPPINGS,
-    **MINIMAX_H3_SEMANTIC_REFERENCE_NODE_DISPLAY_NAME_MAPPINGS,
-}
+NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}
+
+# Sub-packages that imported cleanly, in registration order.
+LOADED_NODE_PACKAGES = []
+# Sub-package name -> the exception that stopped it from loading.
+UNAVAILABLE_NODE_PACKAGES = {}
+
+
+try:
+    from .ltx23_compact_sampler_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["ltx23_compact_sampler_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("ltx23_compact_sampler_node")
+
+try:
+    from .keyframe_maker_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["keyframe_maker_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("keyframe_maker_node")
+
+try:
+    from .z_image_turbo_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["z_image_turbo_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("z_image_turbo_node")
+
+try:
+    from .storyboard_board_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["storyboard_board_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("storyboard_board_node")
+
+try:
+    from .ideogram_layout_builder import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["ideogram_layout_builder"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("ideogram_layout_builder")
+
+try:
+    from .ideogram4_t2i_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["ideogram4_t2i_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("ideogram4_t2i_node")
+
+try:
+    from .ideogram_prompt_polish_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["ideogram_prompt_polish_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("ideogram_prompt_polish_node")
+
+try:
+    from .wan_scail_extend_sampler_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["wan_scail_extend_sampler_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("wan_scail_extend_sampler_node")
+
+try:
+    from .wan_animate2_long_sampler_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["wan_animate2_long_sampler_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("wan_animate2_long_sampler_node")
+
+try:
+    from .hires_upscale_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["hires_upscale_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("hires_upscale_node")
+
+try:
+    from .zit_controlnet_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["zit_controlnet_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("zit_controlnet_node")
+
+try:
+    from .paint_canvas_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["paint_canvas_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("paint_canvas_node")
+
+try:
+    from .load_clip_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["load_clip_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("load_clip_node")
+
+try:
+    from .flux2_klein_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["flux2_klein_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("flux2_klein_node")
+
+try:
+    from .flux2_klein_prompt_director_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["flux2_klein_prompt_director_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("flux2_klein_prompt_director_node")
+
+try:
+    from .reference_board_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["reference_board_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("reference_board_node")
+
+try:
+    from .dreamid_omni_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["dreamid_omni_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("dreamid_omni_node")
+
+try:
+    from .bundle_tools_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["bundle_tools_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("bundle_tools_node")
+
+try:
+    from .layout_text_overlay_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["layout_text_overlay_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("layout_text_overlay_node")
+
+try:
+    from .background_remove_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["background_remove_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("background_remove_node")
+
+try:
+    from .face_mask_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["face_mask_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("face_mask_node")
+
+try:
+    from .flashvsr_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["flashvsr_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("flashvsr_node")
+
+try:
+    from .minimax_h3_image_latent_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["minimax_h3_image_latent_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("minimax_h3_image_latent_node")
+
+try:
+    from .minimax_h3_optional_reference_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["minimax_h3_optional_reference_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("minimax_h3_optional_reference_node")
+
+try:
+    from .minimax_h3_semantic_reference_node import (
+        NODE_CLASS_MAPPINGS as _CLASSES,
+        NODE_DISPLAY_NAME_MAPPINGS as _NAMES,
+    )
+except Exception as exc:  # noqa: BLE001 - one broken package must not hide the rest
+    UNAVAILABLE_NODE_PACKAGES["minimax_h3_semantic_reference_node"] = exc
+else:
+    NODE_CLASS_MAPPINGS.update(_CLASSES)
+    NODE_DISPLAY_NAME_MAPPINGS.update(_NAMES)
+    LOADED_NODE_PACKAGES.append("minimax_h3_semantic_reference_node")
+
+if UNAVAILABLE_NODE_PACKAGES:
+    for _package, _exc in sorted(UNAVAILABLE_NODE_PACKAGES.items()):
+        logger.warning(
+            "[toobusy] skipped node package %s (%s: %s). "
+            "Its optional dependency is probably missing; see the matching "
+            "requirements_*.txt in custom_nodes/toobusy.",
+            _package,
+            type(_exc).__name__,
+            _exc,
+        )
+    logger.warning(
+        "[toobusy] loaded %d node(s) from %d package(s); %d package(s) skipped.",
+        len(NODE_CLASS_MAPPINGS),
+        len(LOADED_NODE_PACKAGES),
+        len(UNAVAILABLE_NODE_PACKAGES),
+    )
 
 WEB_DIRECTORY = "./js"
+
+__all__ = [
+    "NODE_CLASS_MAPPINGS",
+    "NODE_DISPLAY_NAME_MAPPINGS",
+    "LOADED_NODE_PACKAGES",
+    "UNAVAILABLE_NODE_PACKAGES",
+    "WEB_DIRECTORY",
+]

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -31,7 +31,11 @@
   만드는 2단계 워크플로우. 1단계는 얼굴 사진 1장 + 의상 이미지 1장으로 전면·측면·후면 3뷰를 만들고,
   2단계(기본 OFF)는 포즈·소품·배경 패널 1~4장을 더해 최종 16:9 시트로 합성합니다.
   `toobusy MiniMax H3 Image Latent`(T=1 이미지 VAE)와 `toobusy MiniMax H3 Semantic Reference`를 사용하며
-  커스텀 노드 `toobusy` v0.4.9 이상(ComfyUI Manager에서 `toobusy` 검색)과 `rgthree`가 필요합니다. RTX 3090 24GB에서 1단계 약 100~125초, 2단계 약 105초.
+  커스텀 노드 `toobusy` v0.4.9 이상과 `rgthree`가 필요합니다.
+  **`toobusy MiniMax H3 Semantic Reference`는 v0.4.9에서 처음 들어간 노드라, ComfyUI Manager로
+  설치하면 노드 목록에 보이지 않을 수 있습니다.** Manager는 Comfy Registry에 올라간 버전을 받아오는데
+  현재 0.4.9/0.4.10이 레지스트리에서 내려가 있어 0.4.8이 설치됩니다. 이 워크플로우를 쓰려면
+  `git clone https://github.com/nicekriss/toobusy.git` 로 설치하거나 Manager의 **Install via Git URL**을 쓰세요. RTX 3090 24GB에서 1단계 약 100~125초, 2단계 약 105초.
   `_EN` 은 노드/그룹/노트를 전부 영어로 옮기고 한국어 자동번역 단계를 뺀 해외 배포용입니다.
   원본 아이디어: [r/StableDiffusion 게시글](https://www.reddit.com/r/StableDiffusion/comments/1vr1i18/minimax_h3_as_image_editor_6_edits_in_one_shot_at/)
 

--- a/flashvsr_node/__init__.py
+++ b/flashvsr_node/__init__.py
@@ -1,11 +1,28 @@
+"""FlashVSR node package.
+
+Registering the `toobusy_flashvsr` model folder touches the filesystem at import
+time. That is a convenience, not a requirement, so a read-only or missing models
+directory must not stop the nodes from loading.
+"""
+
+import logging
 import os
 
 import folder_paths
 
+logger = logging.getLogger(__name__)
 
-model_dir = os.path.join(folder_paths.models_dir, "FlashVSR")
-os.makedirs(model_dir, exist_ok=True)
-folder_paths.add_model_folder_path("toobusy_flashvsr", model_dir)
+try:
+    model_dir = os.path.join(folder_paths.models_dir, "FlashVSR")
+    os.makedirs(model_dir, exist_ok=True)
+    folder_paths.add_model_folder_path("toobusy_flashvsr", model_dir)
+except OSError as exc:
+    logger.warning(
+        "[toobusy] could not prepare the FlashVSR model folder (%s: %s); "
+        "place the checkpoints under models/FlashVSR manually.",
+        type(exc).__name__,
+        exc,
+    )
 
 from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 

--- a/flashvsr_node/backend/pipelines/flashvsr_full.py
+++ b/flashvsr_node/backend/pipelines/flashvsr_full.py
@@ -263,7 +263,7 @@ class FlashVSRFullPipeline(BasePipeline):
         if context_tensor is None:
             if prompt_path is None:
                 raise ValueError("init_cross_kv: 需要提供 prompt_path 或 context_tensor 其一")
-            ctx = torch.load(prompt_path, map_location=self.device,weights_only=False,) if not prompt_path.endswith('.safetensors') else load_file(prompt_path)
+            ctx = torch.load(prompt_path, map_location=self.device, weights_only=True) if not prompt_path.endswith('.safetensors') else load_file(prompt_path)
         else:
             ctx = context_tensor
 

--- a/flashvsr_node/backend/runtime.py
+++ b/flashvsr_node/backend/runtime.py
@@ -101,7 +101,7 @@ def load_dit_pipeline(handle):
     pipe.denoising_model().LQ_proj_in = Causal_LQ4x_Proj(in_dim=3, out_dim=1536, layer_num=1).to(
         "cpu", dtype=torch.bfloat16
     )
-    projection = torch.load(handle.projection_path, map_location="cpu", weights_only=False)
+    projection = torch.load(handle.projection_path, map_location="cpu", weights_only=True)
     pipe.denoising_model().LQ_proj_in.load_state_dict(projection, strict=True)
     del projection
     pipe.enable_vram_management(num_persistent_param_in_dit=None)

--- a/flux2_klein_node/flux2_klein.py
+++ b/flux2_klein_node/flux2_klein.py
@@ -499,7 +499,7 @@ class ToobusyFlux2Klein:
                 target_w, target_h = manual_size
             else:
                 target_w, target_h = ratio_size
-                print("[toobusy Flux2 Klein] size_mode=manual but width/height are 0 — using ratio + megapixels.")
+                print("[toobusy Flux2 Klein] size_mode=manual but width/height are 0 - using ratio + megapixels.")
         elif size_mode == "ratio + megapixels":
             target_w, target_h = ratio_size
         else:  # "from reference"
@@ -508,7 +508,7 @@ class ToobusyFlux2Klein:
                 target_w, target_h = ref_w, ref_h
             else:
                 target_w, target_h = ratio_size
-                print("[toobusy Flux2 Klein] size_mode=from reference but no reference connected — using ratio + megapixels.")
+                print("[toobusy Flux2 Klein] size_mode=from reference but no reference connected - using ratio + megapixels.")
 
         print(f"[toobusy Flux2 Klein] Output size {target_w}x{target_h} (size_mode: {size_mode}).")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "toobusy"
 description = "toobusy folds tedious multi-step ComfyUI workflows into single production nodes."
-version = "0.4.10"
+version = "0.4.11"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_package_registration.py
+++ b/tests/test_package_registration.py
@@ -1,0 +1,116 @@
+"""Static guarantees about how the toobusy package registers its nodes.
+
+These checks run without a ComfyUI runtime. They exist because the failures they
+cover are invisible until a user installs the package: a node package that was
+written but never wired into `__init__.py`, a node with no display name, one
+broken optional dependency taking down every unrelated node, and unsafe pickle
+deserialization creeping back into the vendored FlashVSR backend.
+"""
+
+import ast
+import pathlib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+IGNORED_DIRS = {"tests", "js", "docs", ".github", ".git", "__pycache__"}
+
+
+def _node_packages():
+    packages = []
+    for entry in sorted(ROOT.iterdir()):
+        if not entry.is_dir() or entry.name in IGNORED_DIRS:
+            continue
+        if not (entry / "__init__.py").is_file():
+            continue
+        packages.append(entry)
+    return packages
+
+
+def _mapping_keys(path, mapping_name):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    keys = set()
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if mapping_name not in targets or not isinstance(node.value, ast.Dict):
+            continue
+        for key in node.value.keys:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                keys.add(key.value)
+    return keys
+
+
+def _package_mapping_keys(package, mapping_name):
+    keys = set()
+    for path in sorted(package.glob("*.py")):
+        keys |= _mapping_keys(path, mapping_name)
+    return keys
+
+
+root_init = ROOT / "__init__.py"
+root_tree = ast.parse(root_init.read_text(encoding="utf-8"))
+
+# 1. Every node package is imported by the root entrypoint.
+imported = {
+    node.module
+    for node in ast.walk(root_tree)
+    if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module
+}
+declared = {package.name for package in _node_packages()}
+missing = sorted(declared - imported)
+assert not missing, f"node packages missing from __init__.py: {missing}"
+
+# 2. Every relative import sits inside its own try/except so one failing package
+#    cannot remove the rest of the node set.
+guarded = set()
+for node in ast.walk(root_tree):
+    if not isinstance(node, ast.Try):
+        continue
+    for child in node.body:
+        if isinstance(child, ast.ImportFrom) and child.level == 1 and child.module:
+            guarded.add(child.module)
+unguarded = sorted(imported - guarded)
+assert not unguarded, f"node package imports are not fault-isolated: {unguarded}"
+
+# 3. Every registered node class has a display name.
+for package in _node_packages():
+    classes = _package_mapping_keys(package, "NODE_CLASS_MAPPINGS")
+    names = _package_mapping_keys(package, "NODE_DISPLAY_NAME_MAPPINGS")
+    undisplayed = sorted(classes - names)
+    assert not undisplayed, f"{package.name} registers nodes with no display name: {undisplayed}"
+
+# 4. No torch.load call may unpickle arbitrary objects, and 5. every console
+#    message stays ASCII so a CJK Windows console (cp949/cp932/cp936) cannot
+#    abort a running node with UnicodeEncodeError.
+for path in sorted(ROOT.rglob("*.py")):
+    if any(part in IGNORED_DIRS for part in path.relative_to(ROOT).parts):
+        continue
+    rel = path.relative_to(ROOT)
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "load":
+            if isinstance(func.value, ast.Name) and func.value.id == "torch":
+                weights_only = [kw for kw in node.keywords if kw.arg == "weights_only"]
+                assert weights_only, f"{rel}:{node.lineno} torch.load without weights_only"
+                value = weights_only[0].value
+                assert isinstance(value, ast.Constant) and value.value is True, (
+                    f"{rel}:{node.lineno} torch.load must use weights_only=True"
+                )
+
+        if isinstance(func, ast.Name) and func.id == "print":
+            for sub in ast.walk(node):
+                if not (isinstance(sub, ast.Constant) and isinstance(sub.value, str)):
+                    continue
+                offenders = sorted({ord(c) for c in sub.value if ord(c) > 127})
+                assert not offenders, (
+                    f"{rel}:{node.lineno} print() contains non-ASCII "
+                    f"{[hex(code) for code in offenders]}; a cp949/cp932 console "
+                    "raises UnicodeEncodeError and kills the node mid-run"
+                )
+
+print(f"Package registration tests passed ({len(declared)} node packages)")

--- a/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
+++ b/wan_scail_extend_sampler_node/wan_scail_extend_sampler.py
@@ -649,7 +649,7 @@ class ToobusyWanSCAILExtendSampler:
                 print(
                     f"[toobusy Wan SCAIL] Warning: planned {requested} output frames exceed "
                     f"pose_video length ({pose_len}). The video can't run longer than the driving "
-                    "pose — shorten the target or supply a longer pose_video."
+                    "pose - shorten the target or supply a longer pose_video."
                 )
 
         if pose_video_mask is not None:
@@ -660,7 +660,7 @@ class ToobusyWanSCAILExtendSampler:
                 print(
                     f"[toobusy Wan SCAIL] Warning: pose_video_mask background looks {estimated} "
                     f"but {mode_name} mode expects {expected}. Set replacement_mode to the SAME "
-                    "value on this node and on 'Create SCAIL-2 Colored Mask' — mismatched mask "
+                    "value on this node and on 'Create SCAIL-2 Colored Mask' - mismatched mask "
                     "conventions degrade quality, especially with multiple people."
                 )
 

--- a/z_image_turbo_node/z_image_turbo.py
+++ b/z_image_turbo_node/z_image_turbo.py
@@ -362,7 +362,7 @@ class ToobusyZImageTurbo:
             print("[toobusy Z-Image Turbo] Using internal CLIP loader.")
             clip = _load_cached("CLIPLoader", clip_name=clip_name, type="lumina2", device="default")
         else:
-            print("[toobusy Z-Image Turbo] Both conditioning overrides connected and no LoRA active — skipping the CLIP loader.")
+            print("[toobusy Z-Image Turbo] Both conditioning overrides connected and no LoRA active - skipping the CLIP loader.")
             clip = None
 
         if vae_override is not None:
@@ -403,7 +403,7 @@ class ToobusyZImageTurbo:
         # change strength.
         if latent_override is not None:
             if image is not None:
-                print("[toobusy Z-Image Turbo] Both latent_override and image connected — the latent wins, image input ignored.")
+                print("[toobusy Z-Image Turbo] Both latent_override and image connected - the latent wins, image input ignored.")
             latent_image = latent_override
             latent_w, latent_h = _latent_dims(latent_override)
             if latent_w > 0 and latent_h > 0:

--- a/zit_controlnet_node/zit_controlnet.py
+++ b/zit_controlnet_node/zit_controlnet.py
@@ -212,10 +212,10 @@ class ToobusyZITControlNet:
         for control_type, image, enabled, strength, preprocess in slots:
             if image is None:
                 if enabled:
-                    print(f"[toobusy ZIT ControlNet] {control_type} is on but has no image connected — skipped.")
+                    print(f"[toobusy ZIT ControlNet] {control_type} is on but has no image connected - skipped.")
                 continue
             if not enabled:
-                print(f"[toobusy ZIT ControlNet] {control_type} image connected but switched off — skipped.")
+                print(f"[toobusy ZIT ControlNet] {control_type} image connected but switched off - skipped.")
                 continue
             processed = (
                 self._preprocess(control_type, image, preprocessor_resolution, canny_low, canny_high)
@@ -226,7 +226,7 @@ class ToobusyZITControlNet:
             previews.append((control_type, processed))
 
         if not entries:
-            print("[toobusy ZIT ControlNet] No active control slot — Z-Image Turbo will run unpatched.")
+            print("[toobusy ZIT ControlNet] No active control slot - Z-Image Turbo will run unpatched.")
 
         control = {"patch_name": patch_name, "entries": entries}
         return {"ui": {"images": _save_previews(previews)}, "result": (control,)}


### PR DESCRIPTION
## Why

A viewer reported that `toobusy MiniMax H3 Semantic Reference` is missing from the node list even though the package installs with no errors and every other toobusy node works. Root cause is outside this repo: versions **0.4.9 and 0.4.10 are `Banned` on the Comfy Registry**, so ComfyUI Manager keeps serving 0.4.8 — the last version that predates those nodes.

Diffing the published `node.zip` for 0.4.8, 0.4.9 and 0.4.10 shows the banned delta is only two pure-Python node packages and two workflow JSONs, with no pattern a scanner would flag. The genuine security flags that do exist in the package are byte-identical in 0.4.8, which is still Active. This PR fixes them anyway, along with three other problems found in the same audit.

## Changes

**Import isolation.** All 25 sub-packages were imported unguarded at the top of `__init__.py`, so one `ImportError` removed all 33 toobusy nodes at once with no explanation — exactly the `diffusers` failure patched reactively in v0.4.10. Each sub-package now imports in its own `try`, a failed package is skipped alone, and `[toobusy] skipped node package <name> (<Error>: <msg>)` goes to the startup log.

**Unsafe deserialization.** `flashvsr_node/backend/runtime.py` and `.../pipelines/flashvsr_full.py` called `torch.load(..., weights_only=False)`, which unpickles arbitrary objects from a checkpoint. Both now use `weights_only=True`.

**CJK console crash.** Nine `print()` calls contained an em dash. On a cp949/cp932 console — the default on Korean and Japanese Windows, and what ComfyUI inherits, since `app/logger.py` copies `stream.encoding` rather than forcing UTF-8 — writing one raises `UnicodeEncodeError` and aborts the node mid-run. Now ASCII.

**FlashVSR import side effect.** The model-folder registration ran unguarded at import time; an unwritable `models/` took the whole package down. It now warns and continues.

**CI gap.** The hand-maintained `compileall` list was missing seven packages (`background_remove_node`, `bundle_tools_node`, `dreamid_omni_node`, `face_mask_node`, `flux2_klein_node`, `flux2_klein_prompt_director_node`, `reference_board_node`) — a syntax error in any of them passed CI. It now compiles the whole repository.

**New test.** `tests/test_package_registration.py` statically checks: every node package is imported by `__init__.py`, every relative import is fault-isolated, every registered node has a display name, no `torch.load` without `weights_only=True`, and no non-ASCII in `print()`.

## Tests

- 26/26 tests pass. Three of them (`test_flux2_klein`, `test_zimage_resolution_i2i`, `test_zit_controlnet`) previously failed on a cp949 console and now pass there.
- Negative checks confirmed: reverting either `weights_only=True` or one `try` block fails the new test.
- Live ComfyUI 0.34.5 / Python 3.13.12: 25/25 packages import, 33 nodes register, 4 MiniMax H3 nodes present.
- Same runtime with `einops` and `onnxruntime` blocked: 23 packages and 28 nodes still register; `flashvsr_node` and `minimax_h3_image_latent_node` are skipped and named in the log. Before this PR that scenario registered nothing.
- Real checkpoints load unchanged under `weights_only=True`: `LQ_proj_in.ckpt` and `LQ_proj_in_v1.1.ckpt` (OrderedDict, 8 entries), `posi_prompt.pth` and `posi_prompt_v1.1.pth` (Tensor).

## Still open

The registry ban reason is not exposed by the public API and nothing in the 0.4.9/0.4.10 diff explains it. If 0.4.11 is banned too, that rules out this package's code and the ban needs to be raised with Comfy Registry support directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
